### PR TITLE
ground_hog now works or without the ground plane

### DIFF
--- a/3rd_party/README.md
+++ b/3rd_party/README.md
@@ -19,3 +19,9 @@ As mentioned the cmake file will take care of almost everything. Just follow the
 	* If you choose to install it in a custom location, you have to make sure that pkg-config finds it: `export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/my/path/lib/pkgconfig` _You can add this to your .bashrc because other projects may need to find it during compile time. If you installed the library to `/usr/local`, you do not have to export any paths._
 * Run make: `make`. _This will download, unpack and build the files._
 * Install library and headers: `sudo make install` _Omit the sudo if you chose a custom destination that does not require sudo rights._
+
+## Troubleshooting
+* If you are on a 32bit system, you will get an error when linking the library: `/usr/bin/ld: cannot find -lcudart`. To get rid of this you have to:
+	* Edit the `build/libcudaHOG/src/libcudaHOG/cudaHOG/cudaHOG.pro` file. _Note: you have to run make before doing so because this will download and unzip the tarball. Otherwise you do not have that file._ 
+	* Find the line that says: `LIBS += -lcudart -L/usr/local/cuda/lib64` and change it to: `LIBS += -lcudart -L/usr/local/cuda/lib`.
+	* Now run `make` again.

--- a/strands_ground_hog/launch/ground_hog_with_GP.launch
+++ b/strands_ground_hog/launch/ground_hog_with_GP.launch
@@ -1,9 +1,10 @@
 <launch>
   <arg name="model_dir" default="$(find strands_ground_hog)/model/config" />
+  <arg name="gp_topic" default="/ground_plane" />
 
   <node pkg="strands_ground_hog" type="groundHOG" name="groundHOG" output="screen">
 		<param name="model" value="$(arg model_dir)" type="string"/>
-                <param name="ground_plane" value="" type="string"/>
-	</node>
+                <param name="ground_plane" value="$(arg gp_topic)" type="string"/>
+  </node>
 
 </launch> 

--- a/strands_visual_odometry/README.md
+++ b/strands_visual_odometry/README.md
@@ -1,0 +1,19 @@
+## Troubleshooting
+If you get an error message that states: 
+```
+/usr/lib/gcc/i686-linux-gnu/4.6/include/emmintrin.h:32:3: error: #error "SSE2 instruction set not enabled"
+```
+or similar, you have to add `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse -msse2 -msse3")` to the CMakeLists.txt file after the
+```
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "-O3")        ## Optimize
+endif()
+```
+statement so that it looks like:
+```
+if(CMAKE_COMPILER_IS_GNUCXX)
+    set(CMAKE_CXX_FLAGS "-O3")        ## Optimize
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse -msse2 -msse3")
+```


### PR DESCRIPTION
If the groundHOG is started with `_ground_plane:=/ground_plane`, it will be used to save computation time. If it is started without this parameter, just the image will be used to estimate the ground plane for every frame.
Also added another launch file bringing it up to two in total:
- `roslaunch strands_ground_hog ground_hog.launch` to just use the image
- `roslaunch strands_ground_hog ground_hog_with_GP.launch` to also use the provided ground plane
  Added some trouble shooting information for the libcudaHOG and visual_odometry
