### PR TITLE
Closing issue #1

### DIFF
--- a/strands_ground_hog/CMakeLists.txt
+++ b/strands_ground_hog/CMakeLists.txt
@@ -6,7 +6,7 @@ project(strands_ground_hog)
 ## is used, also find other catkin packages
 find_package(PkgConfig REQUIRED)
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs strands_perception_people_msgs message_filters)
-pkg_check_modules(CUDAHOG REQUIRED cudaHOG)
+pkg_check_modules(CUDAHOG cudaHOG)
 
 ## Include Qt
 find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
@@ -17,6 +17,12 @@ set(CMAKE_BUILD_TYPE Release)
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "-O3")        ## Optimize
 endif()
+
+if(CUDAHOG_FOUND)
+    add_definitions(-DWITH_CUDA)
+else(CUDAHOG_FOUND)
+    message(WARNING "libcudaHOG not found: Compiling strands_ground_hog without any functionality. This is just a convenience function to not break compilation on systems without NVIDIA graphics cards. People detection will work without the ground_hog but won't be able to detect people far away from the robot. Please install libcudaHOG from the strands_perception_people/3rd_party directory if possible.")
+endif(CUDAHOG_FOUND)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/strands_ground_hog/src/main.cpp
+++ b/strands_ground_hog/src/main.cpp
@@ -1,5 +1,7 @@
 // ROS includes.
 #include <ros/ros.h>
+
+#if WITH_CUDA
 #include <ros/time.h>
 #include <sensor_msgs/Image.h>
 #include "sensor_msgs/CameraInfo.h"
@@ -12,6 +14,7 @@
 #include <string.h>
 #include <QImage>
 #include <QPainter>
+
 
 #include <cudaHOG.h>
 
@@ -279,4 +282,18 @@ int main(int argc, char **argv)
 
     return 0;
 }
+
+#else
+
+int main(int argc, char **argv)
+{
+    // Set up ROS.
+    ros::init(argc, argv, "groundHOG");
+    ros::NodeHandle n;
+    ROS_ERROR("strands_ground_hog package has been compiled without libcudaHOG.");
+    ROS_ERROR("Please see strands_perception_people/3rd_party for instructions.");
+    ROS_ERROR("This node will have no functionality unless compiled with cuda support.");
+}
+
+#endif
 


### PR DESCRIPTION
The strands_ground_hog message now compiles even without libcudaHOG being installed. This is meant to not break the build process on machines without a NVIDIA graphics card. This should be enough to include this repository into the strands_systems files and have it built on the CI server.
The people tracking can still be used with reduced functionality (no detection of people far away from the robot). But this feature is not yet enabled. See issue #4
