### PR TITLE
Patching cudaHOG.cpp to prevent assertion error from creating segfault

### DIFF
--- a/3rd_party/CMakeLists.txt
+++ b/3rd_party/CMakeLists.txt
@@ -17,6 +17,7 @@ ExternalProject_Add(
     libcudaHOG
     PREFIX ${CMAKE_CURRENT_BINARY_DIR}/libcudaHOG
     URL ${groundHOG_tar}
+		PATCH_COMMAND patch -p0 <SOURCE_DIR>/cudaHOG/cudaHOG.cpp < ${CMAKE_CURRENT_SOURCE_DIR}/libcudaHOG/patch/cudaHOG.cpp.diff
     CONFIGURE_COMMAND qmake -makefile <SOURCE_DIR>
     BUILD_COMMAND make
     INSTALL_COMMAND "" #Skipp install step. See below

--- a/3rd_party/libcudaHOG/patch/cudaHOG.cpp.diff
+++ b/3rd_party/libcudaHOG/patch/cudaHOG.cpp.diff
@@ -1,0 +1,110 @@
+--- cudaHOG.cpp	2012-07-10 09:27:01.000000000 +0100
++++ cudaHOG.cpp	2013-08-13 09:50:36.413358001 +0100
+@@ -47,6 +47,14 @@
+ 
+ namespace cudaHOG {
+ 
++struct Exeption {};
++
++template <typename X, typename A>
++inline void Assert(A assertion)
++{
++    if( !assertion ) throw X();
++}
++
+ Parameters g_params;
+ std::vector<ROI> g_roi;
+ 
+@@ -124,12 +132,12 @@
+ 
+ int cudaHOGManager::load_svm_models()
+ {
+-	assert(g_params.path.size() > 0 );
++    Assert<Exeption>(g_params.path.size() > 0 );
+ 
+ 	printf("# models: %d\n", g_params.models.size());
+ 
+ 	for(size_t ii=0; ii < g_params.models.size(); ii++ ) {
+-		assert(g_params.models[ii].identifier.size() > 0 );
++        Assert<Exeption>(g_params.models[ii].identifier.size() > 0 );
+ 
+ 		string fnModel;
+ 		if( g_params.models[ii].filename.length() > 0 )
+@@ -387,9 +395,9 @@
+ 	float x = left;
+ 	float p = (E(1,0) * x + E(2,1) ) / E(1,1);
+ 
+-	assert( p*p >= ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) ));
+-	assert( E(1,1) != 0.f );
+-    assert( p*p - ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) / E(1,1)) >= 0 );
++    Assert<Exeption>( p*p >= ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) ));
++    Assert<Exeption>( E(1,1) != 0.f );
++    Assert<Exeption>( p*p - ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) / E(1,1)) >= 0 );
+ 
+ 	float root = sqrtf( p*p - ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) / E(1,1)));
+ 	yl_0 = -p + root;
+@@ -408,7 +416,7 @@
+ 	x = right;
+ 	p = (E(1,0) * x + E(2,1) ) / E(1,1);
+ 
+-    assert( p*p - ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) / E(1,1)) >= 0 );
++    Assert<Exeption>( p*p - ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) / E(1,1)) >= 0 );
+ 
+ 	root = sqrtf( p*p - ((E(0,0)*x + E(2,2) + 2*E(2,0)*x) / E(1,1)));
+ 	yr_0 = -p + root;
+@@ -497,7 +505,7 @@
+ 	min_y = min( max_height_y_l, max_height_y_r);
+ 	max_y = max( min_height_y_l, min_height_y_r);
+ 
+-	assert( min_y <= max_y );
++    Assert<Exeption>( min_y <= max_y );
+ 	if( min_y > max_y ) {
+ 		// invalid ROI
+ 		min_x =INT_MAX; min_y =INT_MAX; max_x =INT_MIN; max_y =INT_MIN;
+@@ -759,9 +767,9 @@
+ 		sOutput.write((char*)&(features[i].target), sizeof(float));
+ 		for(size_t j=0; j < features[i].values.size(); j++) {
+ #ifdef WIN32
+-			assert(! _isnan(features[i].values[j]) );
++            Assert<Exeption>(! _isnan(features[i].values[j]) );
+ #else
+-			assert(! isnan(features[i].values[j]) );
++            Assert<Exeption>(! isnan(features[i].values[j]) );
+ #endif
+ 			sOutput.write((char*)&(features[i].values[j]), sizeof(float));
+ 		}
+@@ -822,7 +830,10 @@
+ 
+ 	int res = test_image(all_dets);
+ 
+-	detections = all_dets[0];
++    if(all_dets.size() > 0)
++        detections = all_dets[0];
++
++
+ 
+ 	return res;
+ }
+@@ -845,9 +856,10 @@
+ 
+ 	int res =  hog_process_image_multiscale(imgWidth, imgHeight, g_roi, &cntBlocks, &cntSVM, timings, detections);
+ 	release_image();
+-
+-	printf("HOG Blocks: %d\n", cntBlocks);
+-	printf("SVM evaluations: %d\n", cntSVM);
++    if( PRINT_DEBUG_INFO ) {
++        printf("HOG Blocks: %d\n", cntBlocks);
++        printf("SVM evaluations: %d\n", cntSVM);
++    }
+ 
+ 	if( res )
+ 		return 1;
+@@ -1052,7 +1064,7 @@
+ 
+ 			// only one model should be loaded!
+ 			// we only want results from this one model!
+-			assert(tmp_false_positives.size() == 1 );
++            Assert<Exeption>(tmp_false_positives.size() == 1 );
+ 
+ 			for(size_t jj=0; jj < tmp_false_positives[0].size(); jj++) {
+ 				FalsePositive fp;

--- a/strands_ground_hog/src/main.cpp
+++ b/strands_ground_hog/src/main.cpp
@@ -64,7 +64,7 @@ void render_bbox_2D(GroundHOGDetections& detections, QImage& image, int r, int g
 
 void imageCallback(const Image::ConstPtr &msg)
 {
-//    ROS_INFO("Entered img callback");
+    //    ROS_INFO("Entered img callback");
     std::vector<cudaHOG::Detection> detHog;
 
     //  unsigned char image
@@ -121,7 +121,7 @@ void imageCallback(const Image::ConstPtr &msg)
 void imageGroundPlaneCallback(const ImageConstPtr &color, const CameraInfoConstPtr &camera_info,
                               const GroundPlaneConstPtr &gp)
 {
-//    ROS_INFO("Entered gp-img callback");
+    //    ROS_INFO("Entered gp-img callback");
     std::vector<cudaHOG::Detection> detHog;
 
     //  unsigned char image
@@ -157,22 +157,22 @@ void imageGroundPlaneCallback(const ImageConstPtr &color, const CameraInfoConstP
 
     //    float_K.Show();
     //    float_GPN.show();
-    //    printf("%f\n", float_GPd);
+    //    printf("%f\n", float_GPd)
 
-    hog->set_camera(R.data(), float_K.data(), t.data());
-    hog->set_groundplane(float_GPN.data(), &float_GPd);
     try
     {
+        hog->set_camera(R.data(), float_K.data(), t.data());
+        hog->set_groundplane(float_GPN.data(), &float_GPd);
         hog->prepare_roi_by_groundplane();
         hog->test_image(detHog);
-
+        hog->release_image();
     }
     catch(...)
     {
-        ROS_ERROR("GroundHOG: Extracted Ground Plane can not be used for computation of ROIs");
+        ROS_WARN("GroundHOG: Extracted Ground Plane can not be used for computation of ROIs");
     }
 
-    hog->release_image();
+
 
     int w = 64, h = 128;
 


### PR DESCRIPTION
Closing issue #9
Created a patch file for cudaHOG.cpp which replaces the assertion by a custom template which throws exceptions instead of just exiting the programme.

The patch does the following things:
1. It creates a template based Assertion function

``` cpp
struct Exeption {};

template <typename X, typename A>
inline void Assert(A assertion)
{
    if( !assertion ) throw X();
} 
```

and replaces all `assert()` calls with a call to `Assert<Exception>()` to throw an exception which can be caught by strands_ground_hog
2. In the `test_image` function it checks if the size of the resulting vector is greater 0 before assigning values to prevent a segfault
3. It checks if the verbose flag is set to prevent spamming of `HOG Blocks` and `SVM evaluations` output.
