### PR TITLE
using limits.h to set int values, preventing overflow

### DIFF
--- a/strands_upper_body_detector/src/ROI.cpp
+++ b/strands_upper_body_detector/src/ROI.cpp
@@ -2,10 +2,12 @@
 #include "Globals.h"
 #include "Vector.h"
 
+#include <limits.h>
+
 ROI::ROI()
 {
-    min_x = min_y = 1e10;
-    max_x = max_y = 1e-10;
+    min_x = min_y = INT_MAX;
+    max_x = max_y = INT_MIN;
     has_any_point = false;
 }
 


### PR DESCRIPTION
Closing issue #2
This fixes the overflow warning by using limits.h and setting the values to INT_MAX/MIN
Still seems to work for me. Maybe Dennis wants to have a look.
