### PR TITLE
The tracking works without the HOG feature detection now.

### DIFF
--- a/strands_pedestrian_tracking/README.md
+++ b/strands_pedestrian_tracking/README.md
@@ -24,3 +24,13 @@ roslaunch:
 ```
 roslaunch strands_pedestrian_tracking pedestrian_tracking.launch [parameter_name:=value]
 ```
+
+To run the tracker without the groundHOG feture extraction running use:
+```
+rosrun strands_pedestrian_tracking pedestrian_tracker _ground_hog:=""
+```
+or
+
+```
+roslaunch strands_pedestrian_tracking pedestrian_tracking_no_HOG.launch [parameter_name:=value]
+```

--- a/strands_pedestrian_tracking/launch/pedestrian_tracking_no_HOG.launch
+++ b/strands_pedestrian_tracking/launch/pedestrian_tracking_no_HOG.launch
@@ -1,0 +1,30 @@
+<launch>
+    <arg name="visualise" default="false" />
+    <arg name="config_file" default="$(find strands_upper_body_detector)/config/config_Asus.inp" />
+    <arg name="queue_size" default="10" />
+    <arg name="depth_image" default="/camera/depth/image" />
+    <arg name="color_image" default="/camera/rgb/image_color" />
+    <arg name="camera_info" default="/camera/rgb/camera_info" />
+    <arg name="ground_plane" default="/ground_plane" />
+    <arg name="upper_body_detections" default="/upper_body_detector/detections" />
+    <arg name="visual_odometry" default="/visual_odometry/motion_matrix" />
+    <arg name="pedestrian_array" default="/pedestrian_tracking/pedestrian_array" />
+    <arg name="pedestrian_image" default="/pedestrian_tracking/image" />
+
+
+    <node pkg="strands_pedestrian_tracking" type="pedestrian_tracking" name="pedestrian_tracking" output="screen">
+        <param name="visualise" value="$(arg visualise)" type="bool"/>
+        <param name="config_file" value="$(arg config_file)" type="string"/>
+        <param name="queue_size" value="$(arg queue_size)" type="int"/>
+        <param name="depth_image" value="$(arg depth_image)" type="string"/>
+        <param name="color_image" value="$(arg color_image)" type="string"/>
+        <param name="camera_infoe" value="$(arg camera_info)" type="string"/>
+        <param name="ground_plane" value="$(arg ground_plane)" type="string"/>
+        <param name="ground_hog" value="" type="string"/>
+        <param name="visual_odometry" value="$(arg visual_odometry)" type="string"/>
+        <param name="upper_body_detections" value="$(arg upper_body_detections)" type="string"/>
+        <param name="pedestrian_array" value="$(arg pedestrian_array)" type="string"/>
+        <param name="pedestrian_image" value="$(arg pedestrian_image)" type="string"/>
+    </node>
+
+</launch> 

--- a/strands_perception_people_launch/README.md
+++ b/strands_perception_people_launch/README.md
@@ -37,4 +37,34 @@ roslaunch strands_perception_people_launch pedestrian_tracker.launch gh_queue_si
 This will overwrite the default values. _gh = ground_hog, vo = visual_odemetry, ubd = upper_body_detector, pt = pedestrian_tracking_
 
 ### Launching system without ground_hog
-_Not implemented yet_
+This version of the tracking does not rely on the ground_hog feature extraction and is therefore usable on PCs with no NVIDIA graphics card. However, this has the drawback that the system only relies on dpeth data to detect people which limits the distance at which persons can be detected to approx. 5 meters. Wher possible the ground_hog detection should be used to enhance tracking results.
+
+Parameters:
+* `visualise` _default = false_: Set to true to render and publish result images.
+* `gh_queue_size` _default = 20_: The ground plane sync queue size
+* `vo_queue_size` _default = 5_: The visual odometry sync queue size
+* `ubd_queue_size` _default = 5_: The upper body detector sync queue size
+* `pt_queue_size` _default = 10_: The pedestrian tracking sync queue size
+* `model` _default = $(find strands_ground_hog)/model/config_: The ground HOG detection models
+* `config_file` _default = $(find strands_upper_body_detector)/config/config_Asus.inp_: The camera config file
+* `template_file` _default = $(find strands_upper_body_detector)/config/upper_temp_n.txt_: The upper body templates
+* `depth_image` _default = /camera/depth/image_: The Kinect depth image
+* `color_image` _default = /camera/rgb/image_color_: The Kinect colour image
+* `mono_image` _default = /camera/rgb/image_mono_: The Kinect mono image
+* `camera_info` _default = /camera/rgb/camera_info_: The Kinect camera info
+* `ground_plane` _default = /ground_plane_: The estimated ground plane
+* `upper_body_detections` _default = /upper_body_detector/detections_: The detected upper body
+* `upper_body_image` _default = /upper_body_detector/image_: The detected upper body image
+* `visual_odometry` _default = /visual_odometry/motion_matrix_: The visual odometry
+* `pedestrain_array` _default = /pedestrian_tracking/pedestrian_array_: The detected and tracked pedestrians
+
+
+* Launch everything:
+```
+roslaunch strands_perception_people_launch pedestrian_tracker_no_HOG.launch [parameter_name:=value]
+```
+* Launch everything with custom queue sizes: All the the packages rely heavily on the synchronisation of rgb and depth images and the generated data of the other nodes. The synchronization is realised using a queue which saves a predefined number of messages on which the synchronisation is performed. _As a rule of thumb: the faster your machine the shorter the queue to prevent unnecessary use of memory._ You can set queue sizes using:
+```
+roslaunch strands_perception_people_launch pedestrian_tracker_no_HOG.launch vo_queue_size:=22 ubd_queue_size:=33 pt_queue_size:=44
+```
+This will overwrite the default values. _vo = visual_odemetry, ubd = upper_body_detector, pt = pedestrian_tracking_

--- a/strands_perception_people_launch/launch/pedestrian_tracker_no_HOG.launch
+++ b/strands_perception_people_launch/launch/pedestrian_tracker_no_HOG.launch
@@ -1,0 +1,57 @@
+<launch>
+    <!-- Global paramters -->
+    <arg name="visualise" default="false" />
+    <arg name="vo_queue_size" default="5" />
+    <arg name="ubd_queue_size" default="5" />
+    <arg name="pt_queue_size" default="10" />
+    <arg name="model" default="$(find strands_ground_hog)/model/config" />
+    <arg name="config_file" default="$(find strands_upper_body_detector)/config/config_Asus.inp" />
+    <arg name="template_file" default="$(find strands_upper_body_detector)/config/upper_temp_n.txt" />
+    <arg name="depth_image" default="/camera/depth/image" />
+    <arg name="color_image" default="/camera/rgb/image_color" />
+    <arg name="mono_image" default="/camera/rgb/image_mono" />
+    <arg name="camera_info" default="/camera/rgb/camera_info" />
+    <arg name="ground_plane" default="/ground_plane" />
+    <arg name="upper_body_detections" default="/upper_body_detector/detections" />
+    <arg name="upper_body_image" default="/upper_body_detector/image" />
+    <arg name="visual_odometry" default="/visual_odometry/motion_matrix" />
+    <arg name="pedestrian_array" default="/pedestrian_tracking/pedestrian_array" />
+    <arg name="pedestrian_image" default="/pedestrian_tracking/image" />
+
+    <!-- Visual Odometry -->
+    <include file="$(find strands_visual_odometry)/launch/visual_odometry.launch"/>
+        <param name="visual_odometry/queue_size" value="$(arg vo_queue_size)" type="int"/>
+        <param name="visual_odometry/depth_image" value="$(arg depth_image)" type="string"/>
+        <param name="visual_odometry/mono_image" value="$(arg mono_image)" type="string"/>
+        <param name="visual_odometry/camera_info" value="$(arg camera_info)" type="string"/>
+        <param name="visual_odometry/motion_parameters" value="$(arg visual_odometry)" type="string"/>
+
+    <!-- Upper Body Detector -->
+    <include file="$(find strands_upper_body_detector)/launch/upper_body_detector.launch"/>
+        <param name="upper_body_detector/visualise" value="$(arg visualise)" type="bool"/>
+        <param name="upper_body_detector/queue_size" value="$(arg ubd_queue_size)" type="int"/>
+        <param name="upper_body_detector/config_file" value="$(arg config_file)" type="string"/>
+        <param name="upper_body_detector/template_file" value="$(arg template_file)" type="string"/>
+        <param name="upper_body_detector/depth_image" value="$(arg depth_image)" type="string"/>
+        <param name="upper_body_detector/color_image" value="$(arg color_image)" type="string"/>
+        <param name="upper_body_detector/camera_info" value="$(arg camera_info)" type="string"/>
+        <param name="upper_body_detector/upper_body_detections" value="$(arg upper_body_detections)" type="string"/>
+        <param name="upper_body_detector/upper_body_image" value="$(arg upper_body_image)" type="string"/>
+        <param name="upper_body_detector/ground_plane" value="$(arg ground_plane)" type="string"/>
+
+    <!-- Pedestrian Tracking -->
+    <include file="$(find strands_pedestrian_tracking)/launch/pedestrian_tracking.launch"/>
+        <param name="pedestrian_tracking/visualise" value="$(arg visualise)" type="bool"/>
+        <param name="pedestrian_tracking/queue_size" value="$(arg pt_queue_size)" type="int"/>
+        <param name="pedestrian_tracking/config_file" value="$(arg config_file)" type="string"/>
+        <param name="pedestrian_tracking/depth_image" value="$(arg depth_image)" type="string"/>
+        <param name="pedestrian_tracking/color_image" value="$(arg color_image)" type="string"/>
+        <param name="pedestrian_tracking/camera_info" value="$(arg camera_info)" type="string"/>
+        <param name="pedestrian_tracking/ground_plane" value="$(arg ground_plane)" type="string"/>
+        <param name="pedestrian_tracking/ground_hog" value="" type="string"/>
+        <param name="pedestrian_tracking/upper_body_detections" value="$(arg upper_body_detections)" type="string"/>
+        <param name="pedestrian_tracking/visual_odometry" value="$(arg visual_odometry)" type="string"/>
+        <param name="pedestrian_tracking/pedestrain_array" value="$(arg pedestrian_array)" type="string"/>
+        <param name="pedestrian_tracking/pedestrian_image" value="$(arg pedestrian_image)" type="string"/>
+
+</launch> 

--- a/strands_upper_body_detector/config/config_Asus.inp
+++ b/strands_upper_body_detector/config/config_Asus.inp
@@ -140,10 +140,11 @@ probHeight = 0.2
 
 #====================================
 # Visualisation
+# Handled by visualise parameter now
 #====================================
-render_bbox3D = true
-render_bbox2D = false
-render_tracking_numbers = false
+#render_bbox3D = true
+#render_bbox2D = false
+#render_tracking_numbers = false
 
 #========================
 # MDL parameters for trajectories

--- a/strands_upper_body_detector/src/main.cpp
+++ b/strands_upper_body_detector/src/main.cpp
@@ -235,10 +235,11 @@ void ReadConfigFile(string path_config_file)
 
     //======================================
     // Visualisation
+    // Handled by visualise parameter now
     //======================================
-    Globals::render_bbox3D = config.read("render_bbox3D", true);
-    Globals::render_bbox2D = config.read("render_bbox2D", false);
-    Globals::render_tracking_numbers = config.read("render_tracking_numbers", false);
+    //Globals::render_bbox3D = config.read("render_bbox3D", true);
+    //Globals::render_bbox2D = config.read("render_bbox2D", false);
+    //Globals::render_tracking_numbers = config.read("render_tracking_numbers", false);
 
     //======================================
     // MDL parameters for trajectories
@@ -482,8 +483,15 @@ int main(int argc, char **argv)
     pub_message = n.advertise<strands_perception_people_msgs::UpperBodyDetector>(pub_topic.c_str(), 10);
 
     if(visualise) {
+        Globals::render_bbox3D = true;
+        Globals::render_bbox2D = false;
+        Globals::render_tracking_numbers = false;
         private_node_handle_.param("upper_body_image", pub_topic_result_image, string("/upper_body_detector/image"));
         pub_result_image = n.advertise<sensor_msgs::Image>(pub_topic_result_image.c_str(), 10);
+    } else {
+        Globals::render_bbox3D = false;
+        Globals::render_bbox2D = false;
+        Globals::render_tracking_numbers = false;
     }
 
     private_node_handle_.param("ground_plane", pub_topic_gp, string("/ground_plane"));


### PR DESCRIPTION
Closing issue #4
Added launch files for the tracker and the whole tracking system which exclude the groundHOG.
If tracking is started with the ground_hog parameter set to any empty string it will not wait for groundHOG data to compute tracking results.

Bug fix:
- The tracker also subscribed to the depth image topic which is not used in the callbacks. Removed unnecessary subscription.
- The tracker and upper_body_detector still did some rendering because of a config file parameter. This is now all handled by the visualise parameter. See issue #20

Just tested it on the robot. Works like a charm.
