### PR TITLE
The tracking message has been extended by the position in camara coordinates

### DIFF
--- a/strands_pedestrian_tracking/include/AncillaryMethods.h
+++ b/strands_pedestrian_tracking/include/AncillaryMethods.h
@@ -94,6 +94,8 @@ public:
     static void compute_rectangle(Vector<double>& main4D, Vector<double>& ort4D, Vector<double>& Lmax, Vector<double>& x, Matrix<double>& result);
 
 
+    static Vector<double> fromWorldToCamera(Vector<double>& posInWorld, Camera& cam);
+
     ///////////////// Segmentation part /////////////////////////////////////////
     static Matrix<double> conv1D(Matrix<double> &im, Vector<double> &kernel, bool dirFlag);
 

--- a/strands_pedestrian_tracking/include/Camera.h
+++ b/strands_pedestrian_tracking/include/Camera.h
@@ -49,6 +49,7 @@ public:
     void intersectPlane(Vector<double>& gp, double gpd, Vector<double>& ray1, Vector<double>& ray2, Vector<double>& point);
     void jacFor3DCov(Vector<double>& x3d, Matrix<double>& Cov);
     bool isPointInFrontOfCam(const Vector<double> &point) const;
+    Matrix<double> getCameraRotT() const;
 
 private:
 

--- a/strands_pedestrian_tracking/src/AncillaryMethods.cpp
+++ b/strands_pedestrian_tracking/src/AncillaryMethods.cpp
@@ -927,3 +927,14 @@ void AncillaryMethods::ExtractBorder(const Matrix<double>& image, Vector<double>
 
 //    ys = AncillaryMethods::conv1D(ys, AncillaryMethods::getGaussian1D(3,1));
 }
+
+Vector<double> AncillaryMethods::fromWorldToCamera(Vector<double>& posInWorld, Camera& cam)
+{
+    Matrix<double> RT = cam.getCameraRotT();
+
+    Vector<double> t = cam.get_t();
+    t *= Globals::WORLD_SCALE;
+
+    Vector<double> posInCam = RT*(posInWorld-t);
+    return posInCam;
+}

--- a/strands_pedestrian_tracking/src/Camera.cpp
+++ b/strands_pedestrian_tracking/src/Camera.cpp
@@ -278,6 +278,12 @@ void Camera::intersectPlane(Vector<double>& gp, double gpd, Vector<double>& ray1
     point += diffRay;
 }
 
+Matrix<double> Camera::getCameraRotT() const
+{
+	Matrix<double> rotT = Transpose(R_);
+    return rotT;
+}
+
 void Camera::jacFor3DCov(Vector<double>& X, Matrix<double>& Cov)
 {
     Matrix<double> R = Transpose(R_);

--- a/strands_pedestrian_tracking/src/main.cpp
+++ b/strands_pedestrian_tracking/src/main.cpp
@@ -411,6 +411,12 @@ void callbackWithoutHOG(const ImageConstPtr &color,
             oneHypoMsg.traj_x.push_back(trajPts(j)(0));
             oneHypoMsg.traj_y.push_back(trajPts(j)(1));
             oneHypoMsg.traj_z.push_back(trajPts(j)(2));
+            
+             Vector<double> posInCamera = AncillaryMethods::fromWorldToCamera(trajPts(j), camera);
+            
+            oneHypoMsg.traj_x_camera.push_back(posInCamera(0));
+            oneHypoMsg.traj_y_camera.push_back(posInCamera(1));
+            oneHypoMsg.traj_z_camera.push_back(posInCamera(2));
         }
 
         oneHypoMsg.id = hyposMDL(i).getHypoID();
@@ -516,6 +522,13 @@ void callbackWithHOG(const ImageConstPtr &color,
             oneHypoMsg.traj_x.push_back(trajPts(j)(0));
             oneHypoMsg.traj_y.push_back(trajPts(j)(1));
             oneHypoMsg.traj_z.push_back(trajPts(j)(2));
+            
+            Vector<double> posInCamera = AncillaryMethods::fromWorldToCamera(trajPts(j), camera);
+            
+            oneHypoMsg.traj_x_camera.push_back(posInCamera(0));
+            oneHypoMsg.traj_y_camera.push_back(posInCamera(1));
+            oneHypoMsg.traj_z_camera.push_back(posInCamera(2));
+            
         }
 
         oneHypoMsg.id = hyposMDL(i).getHypoID();

--- a/strands_perception_people_msgs/msg/PedestrianTracking.msg
+++ b/strands_perception_people_msgs/msg/PedestrianTracking.msg
@@ -1,7 +1,12 @@
 Header header
+# position projected on the GP in world coordinates
 float64[] traj_x 
-float64[] traj_y # position projected on the GP
+float64[] traj_y 
 float64[] traj_z
+# position projected on the GP in camera coordinates
+float64[] traj_x_camera 
+float64[] traj_y_camera 
+float64[] traj_z_camera 
 float64[] dir 	
 float64 speed 	
 int64 id  


### PR DESCRIPTION
traj_x_camera, traj_y_camera, traj_z_camera represent the trajectory in camera coordinates on the ground plane.

strands_pedestrain_tracker publishes is extended as well to publish these values

Author @dennismitzel (can't open pull requests at the moment)
