### PR TITLE
Publishing 3d position of detected upper bodys

### DIFF
--- a/strands_perception_people_msgs/msg/UpperBodyDetector.msg
+++ b/strands_perception_people_msgs/msg/UpperBodyDetector.msg
@@ -5,3 +5,9 @@ int64[] width 	# width of the bounding box
 int64[] height 	# height of the bounding box
 float64[] dist  # distance of the overlaid area and the template
 float64[] median_depth # median_depth inside the detected bounding box
+
+# 3D position of the middle point of the detected bounding box detection
+float64[] pos_3d_x 
+float64[] pos_3d_y
+float64[] pos_3d_z 
+

--- a/strands_upper_body_detector/src/main.cpp
+++ b/strands_upper_body_detector/src/main.cpp
@@ -378,7 +378,19 @@ void callback(const ImageConstPtr &depth,  const ImageConstPtr &color,const Grou
         detection_msg.height.push_back(detected_bounding_boxes(i)(3));
         detection_msg.dist.push_back(detected_bounding_boxes(i)(4));
         detection_msg.median_depth.push_back(detected_bounding_boxes(i)(5));
+
+
+        detection_msg.pos_3d_z.push_back(detected_bounding_boxes(i)(5));
+
+        double mid_point_x = detected_bounding_boxes(i)(0)+detected_bounding_boxes(i)(2)/2.0;
+        double mid_point_y = detected_bounding_boxes(i)(1)+detected_bounding_boxes(i)(3)/2.0;
+
+        detection_msg.pos_3d_x.push_back(detected_bounding_boxes(i)(5)*((mid_point_x-K(2,0))/K(0,0)));
+        detection_msg.pos_3d_y.push_back(detected_bounding_boxes(i)(5)*((mid_point_y-K(2,1))/K(1,1)));
     }
+
+
+
 
     if(pub_result_image.getNumSubscribers()) {
         ROS_DEBUG("Publishing image");


### PR DESCRIPTION
These are published as the centre points of the bounding boxes.
Can be used to focus people during interaction, for example.

Author: @dennismitzel 
