### PR TITLE
Setting step parameter and switching to image_transport for performance

### DIFF
--- a/strands_ground_hog/CMakeLists.txt
+++ b/strands_ground_hog/CMakeLists.txt
@@ -5,7 +5,7 @@ project(strands_ground_hog)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(PkgConfig REQUIRED)
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs strands_perception_people_msgs message_filters)
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs strands_perception_people_msgs message_filters image_transport)
 pkg_check_modules(CUDAHOG cudaHOG)
 
 ## Include Qt

--- a/strands_ground_hog/package.xml
+++ b/strands_ground_hog/package.xml
@@ -21,6 +21,7 @@
   <build_depend>strands_perception_people_msgs</build_depend>
   <build_depend>message_filters</build_depend>
   <build_depend>libqt4-dev</build_depend>
+  <build_depend>image_transport</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>roscpp</run_depend>
@@ -28,6 +29,7 @@
   <run_depend>strands_perception_people_msgs</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>libqt4-dev</run_depend>
+  <run_depend>image_transport</run_depend>
 
   <export/>
 </package>

--- a/strands_ground_plane/CMakeLists.txt
+++ b/strands_ground_plane/CMakeLists.txt
@@ -4,7 +4,7 @@ project(strands_ground_plane)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS cv_bridge message_filters roscpp std_msgs strands_perception_people_msgs tf sensor_msgs)
+find_package(catkin REQUIRED COMPONENTS cv_bridge message_filters roscpp std_msgs strands_perception_people_msgs tf sensor_msgs image_transport)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)

--- a/strands_ground_plane/package.xml
+++ b/strands_ground_plane/package.xml
@@ -22,6 +22,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>strands_perception_people_msgs</build_depend>
   <build_depend>tf</build_depend>
+  <build_depend>image_transport</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <run_depend>message_filters</run_depend>
@@ -30,6 +31,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>strands_perception_people_msgs</run_depend>
   <run_depend>tf</run_depend>
+  <run_depend>image_transport</run_depend>
   <run_depend>sensor_msgs</run_depend>
 
   <export/>

--- a/strands_ground_plane/src/estimated_gp.cpp
+++ b/strands_ground_plane/src/estimated_gp.cpp
@@ -5,11 +5,12 @@
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
 
-#include "sensor_msgs/Image.h"
-#include "sensor_msgs/CameraInfo.h"
+#include <image_transport/image_transport.h>
+#include <image_transport/subscriber_filter.h>
+#include <sensor_msgs/CameraInfo.h>
 
-#include "string.h"
-#include "boost/thread.hpp"
+#include <string.h>
+#include <boost/thread.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -117,9 +118,13 @@ int main(int argc, char **argv)
 
     ROS_DEBUG("ground_plane: Queue size for synchronisation is set to: %i", queue_size);
 
+    // Image transport handle
+    image_transport::ImageTransport it(private_node_handle_);
+
     // Create a subscriber.
     // Set queue size to 1 because generating a queue here will only pile up images and delay the output by the amount of queued images
-    message_filters::Subscriber<Image> subscriber_depth(n, topic_depth_image.c_str(), 1);
+    image_transport::SubscriberFilter subscriber_depth;
+    subscriber_depth.subscribe(it, topic_depth_image.c_str(), 1);
     message_filters::Subscriber<CameraInfo> subscriber_camera_info(n, topic_camera_info.c_str(), 1);
 
     //The real queue size for synchronisation is set here.

--- a/strands_pedestrian_tracking/CMakeLists.txt
+++ b/strands_pedestrian_tracking/CMakeLists.txt
@@ -4,7 +4,7 @@ project(strands_pedestrian_tracking)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS cv_bridge message_filters roscpp sensor_msgs std_msgs strands_perception_people_msgs)
+find_package(catkin REQUIRED COMPONENTS cv_bridge message_filters roscpp sensor_msgs std_msgs strands_perception_people_msgs image_transport)
 
 find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
 include(${QT_USE_FILE})

--- a/strands_pedestrian_tracking/package.xml
+++ b/strands_pedestrian_tracking/package.xml
@@ -22,6 +22,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>strands_perception_people_msgs</build_depend>
   <build_depend>libqt4-dev</build_depend>
+  <build_depend>image_transport</build_depend>
 
   <run_depend>message_filters</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -30,6 +31,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>strands_perception_people_msgs</run_depend>
   <run_depend>libqt4-dev</run_depend>
+  <run_depend>image_transport</run_depend>
 
   <export/>
 </package>

--- a/strands_upper_body_detector/CMakeLists.txt
+++ b/strands_upper_body_detector/CMakeLists.txt
@@ -4,7 +4,7 @@ project(strands_upper_body_detector)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp cv_bridge sensor_msgs std_msgs strands_perception_people_msgs message_filters geometry_msgs)
+find_package(catkin REQUIRED COMPONENTS roscpp cv_bridge sensor_msgs std_msgs strands_perception_people_msgs message_filters geometry_msgs image_transport)
 
 find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
 include(${QT_USE_FILE})

--- a/strands_upper_body_detector/package.xml
+++ b/strands_upper_body_detector/package.xml
@@ -22,6 +22,7 @@
   <build_depend>strands_perception_people_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>libqt4-dev</build_depend>
+  <build_depend>image_transport</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -30,6 +31,7 @@
   <run_depend>strands_perception_people_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>libqt4-dev</run_depend>
+  <run_depend>image_transport</run_depend>
 
   <export/>
 </package>

--- a/strands_visual_odometry/CMakeLists.txt
+++ b/strands_visual_odometry/CMakeLists.txt
@@ -5,7 +5,7 @@ project(strands_visual_odometry)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(PkgConfig REQUIRED)
-find_package(catkin REQUIRED COMPONENTS message_generation roscpp sensor_msgs std_msgs message_filters strands_perception_people_msgs cv_bridge)
+find_package(catkin REQUIRED COMPONENTS message_generation roscpp sensor_msgs std_msgs message_filters strands_perception_people_msgs cv_bridge image_transport)
 pkg_check_modules(EIGEN REQUIRED eigen3)
 
 set(CMAKE_BUILD_TYPE Release)

--- a/strands_visual_odometry/package.xml
+++ b/strands_visual_odometry/package.xml
@@ -20,12 +20,14 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>strands_perception_people_msgs</build_depend>
+  <build_depend>image_transport</build_depend>
 
   <run_depend>eigen</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>strands_perception_people_msgs</run_depend>
+  <run_depend>image_transport</run_depend>
 
   <export/>
 </package>

--- a/strands_visual_odometry/src/main.cpp
+++ b/strands_visual_odometry/src/main.cpp
@@ -4,7 +4,8 @@
 #include <message_filters/subscriber.h>
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
-#include <sensor_msgs/Image.h>
+#include <image_transport/image_transport.h>
+#include <image_transport/subscriber_filter.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <cv_bridge/cv_bridge.h>
 
@@ -144,10 +145,15 @@ int main(int argc, char **argv)
 
     ROS_DEBUG("visual_odometry: Queue size for synchronisation is set to: %i", queue_size);
 
+    // Image transport handle
+    image_transport::ImageTransport it(private_node_handle_);
+
     // Create a subscriber.
     // Set queue size to 1 because generating a queue here will only pile up images and delay the output by the amount of queued images
-    Subscriber<Image> subscriber_mono(n, topic_image_mono.c_str(), 1);
-    Subscriber<Image> subscriber_depth(n, topic_depth_image.c_str(), 1);
+    image_transport::SubscriberFilter subscriber_mono;
+    subscriber_mono.subscribe(it, topic_image_mono.c_str(), 1);
+    image_transport::SubscriberFilter subscriber_depth;
+    subscriber_depth.subscribe(it, topic_depth_image.c_str(), 1);
     Subscriber<CameraInfo> subscriber_camera_info(n, topic_camera_info.c_str(), 1);
 
     //The real queue size for synchronisation is set here.


### PR DESCRIPTION
Closing issue #49
Enhancing performance by switching to image_transport instead of publishing the image directly. Also supports compressed images and theora.
