### PR TITLE
Dynamically (un)subscribe to topics if output is requested.

### DIFF
--- a/strands_ground_hog/src/main.cpp
+++ b/strands_ground_hog/src/main.cpp
@@ -234,13 +234,13 @@ void connectCallback(ros::Subscriber &sub_msg,
                      image_transport::SubscriberFilter &sub_col,
                      image_transport::ImageTransport &it){
     if(!pub_message.getNumSubscribers() && !pub_result_image.getNumSubscribers()) {
-        ROS_INFO("HOG: No subscribers. Unsubscribing.");
+        ROS_DEBUG("HOG: No subscribers. Unsubscribing.");
         sub_msg.shutdown();
         sub_gp.unsubscribe();
         sub_cam.unsubscribe();
         sub_col.unsubscribe();
     } else {
-        ROS_INFO("HOG: New subscribers. Subscribing.");
+        ROS_DEBUG("HOG: New subscribers. Subscribing.");
         if(strcmp(gp_topic.c_str(), "") == 0) {
             sub_msg = n.subscribe(img_topic.c_str(), 1, &imageCallback);
         }

--- a/strands_ground_hog/src/main.cpp
+++ b/strands_ground_hog/src/main.cpp
@@ -224,6 +224,32 @@ void imageGroundPlaneCallback(const ImageConstPtr &color, const CameraInfoConstP
 
 }
 
+// Connection callback that unsubscribes from the tracker if no one is subscribed.
+void connectCallback(ros::Subscriber &sub_msg,
+                     ros::NodeHandle &n,
+                     string gp_topic,
+                     string img_topic,
+                     Subscriber<GroundPlane> &sub_gp,
+                     Subscriber<CameraInfo> &sub_cam,
+                     image_transport::SubscriberFilter &sub_col,
+                     image_transport::ImageTransport &it){
+    if(!pub_message.getNumSubscribers() && !pub_result_image.getNumSubscribers()) {
+        ROS_INFO("HOG: No subscribers. Unsubscribing.");
+        sub_msg.shutdown();
+        sub_gp.unsubscribe();
+        sub_cam.unsubscribe();
+        sub_col.unsubscribe();
+    } else {
+        ROS_INFO("HOG: New subscribers. Subscribing.");
+        if(strcmp(gp_topic.c_str(), "") == 0) {
+            sub_msg = n.subscribe(img_topic.c_str(), 1, &imageCallback);
+        }
+        sub_cam.subscribe();
+        sub_gp.subscribe();
+        sub_col.subscribe(it,sub_col.getTopic().c_str(),1);
+    }
+}
+
 int main(int argc, char **argv)
 {
     // Set up ROS.
@@ -272,10 +298,30 @@ int main(int argc, char **argv)
     // Name the topic, message queue, callback function with class name, and object containing callback function.
     // Set queue size to 1 because generating a queue here will only pile up images and delay the output by the amount of queued images
     ros::Subscriber sub_message; //Subscribers have to be defined out of the if scope to have affect.
-    Subscriber<GroundPlane> subscriber_ground_plane(n, ground_plane.c_str(), 1);
+    Subscriber<GroundPlane> subscriber_ground_plane(n, ground_plane.c_str(), 1); subscriber_ground_plane.unsubscribe();
     image_transport::SubscriberFilter subscriber_color;
-    subscriber_color.subscribe(it, image_color.c_str(), 1);
-    Subscriber<CameraInfo> subscriber_camera_info(n, camera_info.c_str(), 1);
+    subscriber_color.subscribe(it, image_color.c_str(), 1); subscriber_color.unsubscribe();
+    Subscriber<CameraInfo> subscriber_camera_info(n, camera_info.c_str(), 1); subscriber_camera_info.unsubscribe();
+
+    ros::SubscriberStatusCallback con_cb = boost::bind(&connectCallback,
+                                                       boost::ref(sub_message),
+                                                       boost::ref(n),
+                                                       ground_plane,
+                                                       image_color,
+                                                       boost::ref(subscriber_ground_plane),
+                                                       boost::ref(subscriber_camera_info),
+                                                       boost::ref(subscriber_color),
+                                                       boost::ref(it));
+
+    image_transport::SubscriberStatusCallback image_cb = boost::bind(&connectCallback,
+                                                                   boost::ref(sub_message),
+                                                                   boost::ref(n),
+                                                                   ground_plane,
+                                                                   image_color,
+                                                                   boost::ref(subscriber_ground_plane),
+                                                                   boost::ref(subscriber_camera_info),
+                                                                   boost::ref(subscriber_color),
+                                                                   boost::ref(it));
 
     //The real queue size for synchronisation is set here.
     sync_policies::ApproximateTime<Image, CameraInfo, GroundPlane> MySyncPolicy(queue_size);
@@ -296,10 +342,10 @@ int main(int argc, char **argv)
 
     // Create publishers
     private_node_handle_.param("detections", pub_topic, string("/groundHOG/detections"));
-    pub_message = n.advertise<strands_perception_people_msgs::GroundHOGDetections>(pub_topic.c_str(), 10);
+    pub_message = n.advertise<strands_perception_people_msgs::GroundHOGDetections>(pub_topic.c_str(), 10, con_cb, con_cb);
 
     private_node_handle_.param("result_image", pub_image_topic, string("/groundHOG/image"));
-    pub_result_image = it.advertise(pub_image_topic.c_str(), 1);
+    pub_result_image = it.advertise(pub_image_topic.c_str(), 1, image_cb, image_cb);
 
     ros::spin();
 

--- a/strands_ground_plane/src/estimated_gp.cpp
+++ b/strands_ground_plane/src/estimated_gp.cpp
@@ -92,11 +92,11 @@ void connectCallback(message_filters::Subscriber<CameraInfo> &sub_cam,
                      image_transport::SubscriberFilter &sub_depth,
                      image_transport::ImageTransport &it){
     if(!pub_ground_plane.getNumSubscribers()) {
-        ROS_INFO("Ground Plane estimated: No subscribers. Unsubscribing.");
+        ROS_DEBUG("Ground Plane estimated: No subscribers. Unsubscribing.");
         sub_cam.unsubscribe();
         sub_depth.unsubscribe();
     } else {
-        ROS_INFO("Ground Plane estimated: New subscribers. Subscribing.");
+        ROS_DEBUG("Ground Plane estimated: New subscribers. Subscribing.");
         sub_cam.subscribe();
         sub_depth.subscribe(it,sub_depth.getTopic().c_str(),1);
     }

--- a/strands_pedestrian_localisation/src/main.cpp
+++ b/strands_pedestrian_localisation/src/main.cpp
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("pedestrian_array", pta_topic, string("/pedestrian_tracking/pedestrian_array"));
 
     // Create a subscriber.
-    ros::Subscriber pta_sub;// = n.subscribe(pta_topic.c_str(), 10, &trackingCallback);
+    ros::Subscriber pta_sub;
     ros::SubscriberStatusCallback con_cb = boost::bind(&connectCallback, boost::ref(n), boost::ref(pta_sub), pta_topic);
 
     private_node_handle_.param("localisations", pub_topic, string("/pedestrian_localisation/localisations"));

--- a/strands_pedestrian_localisation/src/main.cpp
+++ b/strands_pedestrian_localisation/src/main.cpp
@@ -172,10 +172,10 @@ void connectCallback(ros::NodeHandle &n, ros::Subscriber &sub, string topic) {
     bool loc = pub_detect.getNumSubscribers();
     bool markers = pub_marker.getNumSubscribers();
     if(!loc && !markers) {
-        ROS_DEBUG("No subscribers. Unsubscribing.");
+        ROS_DEBUG("Pedestrian Localisation: No subscribers. Unsubscribing.");
         sub.shutdown();
     } else {
-        ROS_DEBUG("New subscribers. Subscribing.");
+        ROS_DEBUG("Pedestrian Localisation: New subscribers. Subscribing.");
         sub = n.subscribe(topic.c_str(), 10, &trackingCallback);
     }
 }

--- a/strands_pedestrian_tracking/src/main.cpp
+++ b/strands_pedestrian_tracking/src/main.cpp
@@ -573,7 +573,7 @@ void connectCallback(message_filters::Subscriber<CameraInfo> &sub_cam,
                      image_transport::SubscriberFilter &sub_col,
                      image_transport::ImageTransport &it){
     if(!pub_message.getNumSubscribers() && !pub_image.getNumSubscribers()) {
-        ROS_INFO("Tracker: No subscribers. Unsubscribing.");
+        ROS_DEBUG("Tracker: No subscribers. Unsubscribing.");
         sub_cam.unsubscribe();
         sub_gp.unsubscribe();
         sub_hog.unsubscribe();
@@ -581,7 +581,7 @@ void connectCallback(message_filters::Subscriber<CameraInfo> &sub_cam,
         sub_vo.unsubscribe();
         sub_col.unsubscribe();
     } else {
-        ROS_INFO("Tracker: New subscribers. Subscribing.");
+        ROS_DEBUG("Tracker: New subscribers. Subscribing.");
         sub_cam.subscribe();
         sub_gp.subscribe();
         sub_hog.subscribe();

--- a/strands_upper_body_detector/src/main.cpp
+++ b/strands_upper_body_detector/src/main.cpp
@@ -254,13 +254,13 @@ void connectCallback(message_filters::Subscriber<CameraInfo> &sub_cam,
                      image_transport::SubscriberFilter &sub_dep,
                      image_transport::ImageTransport &it){
     if(!pub_message.getNumSubscribers() && !pub_result_image.getNumSubscribers() && !pub_centres.getNumSubscribers()) {
-        ROS_INFO("Tracker: No subscribers. Unsubscribing.");
+        ROS_DEBUG("Upper Body Detector: No subscribers. Unsubscribing.");
         sub_cam.unsubscribe();
         sub_gp.unsubscribe();
         sub_col.unsubscribe();
         sub_dep.unsubscribe();
     } else {
-        ROS_INFO("Tracker: New subscribers. Subscribing.");
+        ROS_DEBUG("Upper Body Detector: New subscribers. Subscribing.");
         sub_cam.subscribe();
         sub_gp.subscribe();
         sub_col.subscribe(it,sub_col.getTopic().c_str(),1);

--- a/strands_visual_odometry/src/main.cpp
+++ b/strands_visual_odometry/src/main.cpp
@@ -126,12 +126,12 @@ void connectCallback(message_filters::Subscriber<CameraInfo> &sub_cam,
                      image_transport::SubscriberFilter &sub_dep,
                      image_transport::ImageTransport &it){
     if(!pub_message.getNumSubscribers()) {
-        ROS_INFO("Tracker: No subscribers. Unsubscribing.");
+        ROS_DEBUG("Visual Odometry: No subscribers. Unsubscribing.");
         sub_cam.unsubscribe();
         sub_mon.unsubscribe();
         sub_dep.unsubscribe();
     } else {
-        ROS_INFO("Tracker: New subscribers. Subscribing.");
+        ROS_DEBUG("Visual Odometry: New subscribers. Subscribing.");
         sub_cam.subscribe();
         sub_mon.subscribe(it,sub_mon.getTopic().c_str(),1);
         sub_dep.subscribe(it,sub_dep.getTopic().c_str(),1);

--- a/strands_visual_odometry/src/main.cpp
+++ b/strands_visual_odometry/src/main.cpp
@@ -120,6 +120,23 @@ void callback(const ImageConstPtr &image, const ImageConstPtr &depth, const Came
     }
 }
 
+// Connection callback that unsubscribes from the tracker if no one is subscribed.
+void connectCallback(message_filters::Subscriber<CameraInfo> &sub_cam,
+                     image_transport::SubscriberFilter &sub_mon,
+                     image_transport::SubscriberFilter &sub_dep,
+                     image_transport::ImageTransport &it){
+    if(!pub_message.getNumSubscribers()) {
+        ROS_INFO("Tracker: No subscribers. Unsubscribing.");
+        sub_cam.unsubscribe();
+        sub_mon.unsubscribe();
+        sub_dep.unsubscribe();
+    } else {
+        ROS_INFO("Tracker: New subscribers. Subscribing.");
+        sub_cam.subscribe();
+        sub_mon.subscribe(it,sub_mon.getTopic().c_str(),1);
+        sub_dep.subscribe(it,sub_dep.getTopic().c_str(),1);
+    }
+}
 
 int main(int argc, char **argv)
 {
@@ -151,10 +168,16 @@ int main(int argc, char **argv)
     // Create a subscriber.
     // Set queue size to 1 because generating a queue here will only pile up images and delay the output by the amount of queued images
     image_transport::SubscriberFilter subscriber_mono;
-    subscriber_mono.subscribe(it, topic_image_mono.c_str(), 1);
+    subscriber_mono.subscribe(it, topic_image_mono.c_str(), 1); subscriber_mono.unsubscribe();
     image_transport::SubscriberFilter subscriber_depth;
-    subscriber_depth.subscribe(it, topic_depth_image.c_str(), 1);
-    Subscriber<CameraInfo> subscriber_camera_info(n, topic_camera_info.c_str(), 1);
+    subscriber_depth.subscribe(it, topic_depth_image.c_str(), 1); subscriber_depth.unsubscribe();
+    Subscriber<CameraInfo> subscriber_camera_info(n, topic_camera_info.c_str(), 1); subscriber_camera_info.unsubscribe();
+
+    ros::SubscriberStatusCallback con_cb = boost::bind(&connectCallback,
+                                                       boost::ref(subscriber_camera_info),
+                                                       boost::ref(subscriber_mono),
+                                                       boost::ref(subscriber_depth),
+                                                       boost::ref(it));
 
     //The real queue size for synchronisation is set here.
     sync_policies::ApproximateTime<Image, Image, CameraInfo> MySyncPolicy(queue_size);
@@ -168,7 +191,7 @@ int main(int argc, char **argv)
     sync.registerCallback(boost::bind(&callback, _1, _2, _3));
     // Create a topic publisher
     private_node_handle_.param("motion_parameters", pub_topic, string("/visual_odometry/motion_matrix"));
-    pub_message = n.advertise<VisualOdometry>(pub_topic.c_str(), 10);
+    pub_message = n.advertise<VisualOdometry>(pub_topic.c_str(), 10, con_cb, con_cb);
 
     ros::spin();
 


### PR DESCRIPTION
Solving issue #52

Implementing a `SubscriberStatusCallback` which is triggered every time
someone (un)subscribes to the published topic, using it to (un)subscribe
to topics that supply the data for the actual calculations.
This allows to have the people perception running without using any CPU
if there is no component connected to it and only do calculations if another
node connects to it.
