### PR TITLE
Adaptation to new openni2 wrapper and using robot odometry

### DIFF
--- a/strands_ground_hog/src/main.cpp
+++ b/strands_ground_hog/src/main.cpp
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("camera_namespace", camera_ns, string("/head_xtion"));
     private_node_handle_.param("ground_plane", ground_plane, string(""));
 
-    string image_color = camera_ns + "/rgb/image_color";
+    string image_color = camera_ns + "/rgb/image_rect_color";
     string camera_info = camera_ns + "/rgb/camera_info";
 
 

--- a/strands_ground_plane/src/estimated_gp.cpp
+++ b/strands_ground_plane/src/estimated_gp.cpp
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("config_file", config_file, string(""));
 
     private_node_handle_.param("camera_namespace", cam_ns, string("/head_xtion"));
-    string topic_depth_image = cam_ns + "/depth/image";
+    string topic_depth_image = cam_ns + "/depth/image_rect";
     string topic_camera_info = cam_ns + "/rgb/camera_info";
 
     if(strcmp(config_file.c_str(),"") == 0) {

--- a/strands_ground_plane/src/estimated_gp.cpp
+++ b/strands_ground_plane/src/estimated_gp.cpp
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("config_file", config_file, string(""));
 
     private_node_handle_.param("camera_namespace", cam_ns, string("/head_xtion"));
-    string topic_depth_image = cam_ns + "/depth/image_rect";
+    string topic_depth_image = cam_ns + "/depth/image_rect_meters";
     string topic_camera_info = cam_ns + "/rgb/camera_info";
 
     if(strcmp(config_file.c_str(),"") == 0) {

--- a/strands_pedestrian_tracking/src/main.cpp
+++ b/strands_pedestrian_tracking/src/main.cpp
@@ -625,7 +625,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("upper_body_detections", topic_upperbody, string("/upper_body_detector/detections"));
     private_node_handle_.param("visual_odometry", topic_vo, string("/visual_odometry/motion_matrix"));
 
-    string topic_color_image = cam_ns + "/rgb/image_color";
+    string topic_color_image = cam_ns + "/rgb/image_rect_color";
     string topic_camera_info = cam_ns + "/rgb/camera_info";
 
     if(strcmp(config_file.c_str(),"") == 0) {

--- a/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
+++ b/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
@@ -1,7 +1,7 @@
 <launch>
     <!-- Global paramters -->
     <arg name="gp_queue_size" default="5" />
-    <arg name="vo_queue_size" default="5" />
+    <!-- <arg name="vo_queue_size" default="5" /> -->
     <arg name="ubd_queue_size" default="5" />
     <arg name="pt_queue_size" default="10" />
     <arg name="model" default="$(find strands_ground_hog)/model/config" />
@@ -11,6 +11,7 @@
     <arg name="ptu_state" default="/ptu/state" />
     <arg name="template_file" default="$(find strands_upper_body_detector)/config/upper_temp_n.txt" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="odom" default="/odom" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
     <arg name="upper_body_bb_centres" default="/upper_body_detector/bounding_box_centres" />
@@ -22,10 +23,16 @@
     <arg name="pd_localisations" default="/pedestrian_localisation/localisations" />
     <arg name="pd_marker" default="/pedestrian_localisation/marker_array" />
 
-    <!-- Visual Odometry -->
+    <!-- Visual Odometry 
     <include file="$(find strands_visual_odometry)/launch/visual_odometry.launch">
         <arg name="queue_size" value="$(arg vo_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="motion_parameters" value="$(arg visual_odometry)"/>
+    </include> -->
+
+   <!-- Odometry -->
+    <include file="$(find strands_perception_people_utils)/launch/odom2visual.launch">
+        <arg name="odom" value="$(arg odom)"/>
         <arg name="motion_parameters" value="$(arg visual_odometry)"/>
     </include>
 

--- a/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
+++ b/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
@@ -30,7 +30,7 @@
         <arg name="motion_parameters" value="$(arg visual_odometry)"/>
     </include> -->
 
-   <!-- Odometry -->
+    <!-- Odometry -->
     <include file="$(find strands_perception_people_utils)/launch/odom2visual.launch">
         <arg name="odom" value="$(arg odom)"/>
         <arg name="motion_parameters" value="$(arg visual_odometry)"/>

--- a/strands_perception_people_utils/CMakeLists.txt
+++ b/strands_perception_people_utils/CMakeLists.txt
@@ -1,0 +1,172 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(strands_perception_people_utils)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(PkgConfig REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  eigen
+  eigen_conversions
+  nav_msgs
+  roscpp
+  sensor_msgs
+  std_msgs
+  strands_perception_people_msgs
+  tf
+  tf_conversions
+)
+pkg_check_modules(EIGEN REQUIRED eigen3)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   sensor_msgs#   std_msgs#   strands_perception_people_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES strands_perception_people_utils
+#  CATKIN_DEPENDS eigen roscpp sensor_msgs std_msgs strands_perception_people_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+# add_library(strands_perception_people_utils
+#   src/${PROJECT_NAME}/strands_perception_people_utils.cpp
+# )
+
+## Declare a cpp executable
+add_executable(odom2visual src/odom2visual/main.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+add_dependencies(odom2visual strands_perception_people_msgs_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+target_link_libraries(odom2visual
+  ${catkin_LIBRARIES}
+)
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS strands_perception_people_utils strands_perception_people_utils_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_strands_perception_people_utils.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/strands_perception_people_utils/launch/odom2visual.launch
+++ b/strands_perception_people_utils/launch/odom2visual.launch
@@ -1,0 +1,9 @@
+<launch>
+    <arg name="odom" default="/odom" />
+    <arg name="motion_parameters" default="/visual_odometry/motion_matrix" />
+
+    <node pkg="strands_perception_people_utils" type="odom2visual" name="odom2visual" output="screen">
+        <param name="odom" value="$(arg odom)" type="string"/>
+        <param name="motion_parameters" value="$(arg motion_parameters)" type="string"/>
+    </node>
+</launch> 

--- a/strands_perception_people_utils/package.xml
+++ b/strands_perception_people_utils/package.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<package>
+  <name>strands_perception_people_utils</name>
+  <version>0.0.0</version>
+  <description>The strands_perception_people_utils package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="cdondrup@todo.todo">cdondrup</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/strands_perception_people_utils</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>eigen</build_depend>
+  <build_depend>eigen_conversions</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>strands_perception_people_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>tf_conversions</build_depend>
+  <run_depend>eigen</run_depend>
+  <run_depend>eigen_conversions</run_depend>
+  <run_depend>nav_msgs</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>strands_perception_people_msgs</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>tf_conversions</run_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/strands_perception_people_utils/src/odom2visual/main.cpp
+++ b/strands_perception_people_utils/src/odom2visual/main.cpp
@@ -1,0 +1,79 @@
+// ROS includes.
+#include <ros/ros.h>
+#include <ros/time.h>
+#include <nav_msgs/Odometry.h>
+#include <tf/transform_datatypes.h>
+#include <tf_conversions/tf_eigen.h>
+#include <eigen_conversions/eigen_msg.h>
+
+#include <Eigen/Geometry>
+
+#include <string.h>
+#include <iostream>
+#include <fstream>
+#include <math.h>
+
+#include "strands_perception_people_msgs/VisualOdometry.h"
+
+ros::Publisher pub_message;
+
+void callback(const nav_msgs::OdometryConstPtr& odom) {
+    ROS_INFO("Received odom");
+    Eigen::Affine3d eigenTr;
+    tf::poseMsgToEigen(odom->pose.pose, eigenTr);
+    Eigen::Matrix4d m = eigenTr.matrix().inverse();
+
+    strands_perception_people_msgs::VisualOdometry fovis_info_msg;
+    fovis_info_msg.header = odom->header;
+    fovis_info_msg.motion_estimate_valid = true;
+    fovis_info_msg.transformation_matrix.resize(4*4);
+    for(int i = 0; i < 4*4; i++)
+        fovis_info_msg.transformation_matrix[i] = m.data()[i];
+     pub_message.publish(fovis_info_msg);
+}
+
+// Connection callback that unsubscribes from the tracker if no one is subscribed.
+void connectCallback(ros::Subscriber &sub_odom,
+                     ros::NodeHandle &n,
+                     std::string odom_topic){
+    if(!pub_message.getNumSubscribers()) {
+        ROS_INFO("Odom: No subscribers. Unsubscribing.");
+        sub_odom.shutdown();
+    } else {
+        ROS_INFO("Odom: New subscribers. Subscribing.");
+        sub_odom = n.subscribe(odom_topic.c_str(), 1, &callback);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    // Set up ROS.
+    ros::init(argc, argv, "odom2visual");
+    ros::NodeHandle n;
+
+    // Declare variables that can be modified by launch file or command line.
+    std::string odom_topic;
+    std::string pub_topic;
+
+    // Initialize node parameters from launch file or command line.
+    // Use a private node handle so that multiple instances of the node can be run simultaneously
+    // while using different parameters.
+    ros::NodeHandle private_node_handle_("~");
+    private_node_handle_.param("odom", odom_topic, std::string("/odom"));
+
+    // Create a subscriber.
+    // Set queue size to 1 because generating a queue here will only pile up images and delay the output by the amount of queued images
+    ros::Subscriber sub_odom; //Subscribers have to be defined out of the if scope to have effect.
+
+    ros::SubscriberStatusCallback con_cb = boost::bind(&connectCallback,
+                                                       boost::ref(sub_odom),
+                                                       boost::ref(n),
+                                                       odom_topic);
+
+    private_node_handle_.param("motion_parameters", pub_topic, std::string("/visual_odometry/motion_matrix"));
+    pub_message = n.advertise<strands_perception_people_msgs::VisualOdometry>(pub_topic.c_str(), 10, con_cb, con_cb);
+
+    ros::spin();
+
+    return 0;
+}

--- a/strands_perception_people_utils/src/odom2visual/main.cpp
+++ b/strands_perception_people_utils/src/odom2visual/main.cpp
@@ -18,7 +18,6 @@
 ros::Publisher pub_message;
 
 void callback(const nav_msgs::OdometryConstPtr& odom) {
-    ROS_INFO("Received odom");
     Eigen::Affine3d eigenTr;
     tf::poseMsgToEigen(odom->pose.pose, eigenTr);
     Eigen::Matrix4d m = eigenTr.matrix().inverse();
@@ -37,10 +36,10 @@ void connectCallback(ros::Subscriber &sub_odom,
                      ros::NodeHandle &n,
                      std::string odom_topic){
     if(!pub_message.getNumSubscribers()) {
-        ROS_INFO("Odom: No subscribers. Unsubscribing.");
+        ROS_DEBUG("Odom: No subscribers. Unsubscribing.");
         sub_odom.shutdown();
     } else {
-        ROS_INFO("Odom: New subscribers. Subscribing.");
+        ROS_DEBUG("Odom: New subscribers. Subscribing.");
         sub_odom = n.subscribe(odom_topic.c_str(), 1, &callback);
     }
 }

--- a/strands_upper_body_detector/src/main.cpp
+++ b/strands_upper_body_detector/src/main.cpp
@@ -297,8 +297,8 @@ int main(int argc, char **argv)
     private_node_handle_.param("camera_namespace", cam_ns, string("/camera"));
     private_node_handle_.param("ground_plane", topic_gp, string("/ground_plane"));
 
-    string topic_depth_image = cam_ns + "/depth/image";
-    string topic_color_image = cam_ns + "/rgb/image_color";
+    string topic_depth_image = cam_ns + "/depth/image_rect";
+    string topic_color_image = cam_ns + "/rgb/image_rect_color";
     string topic_camera_info = cam_ns + "/rgb/camera_info";
    
     // Checking if all config files could be loaded

--- a/strands_upper_body_detector/src/main.cpp
+++ b/strands_upper_body_detector/src/main.cpp
@@ -297,9 +297,9 @@ int main(int argc, char **argv)
     private_node_handle_.param("camera_namespace", cam_ns, string("/camera"));
     private_node_handle_.param("ground_plane", topic_gp, string("/ground_plane"));
 
-    string topic_depth_image = cam_ns + "/depth/image_rect";
+    string topic_depth_image = cam_ns + "/depth/image_rect_meters";
     string topic_color_image = cam_ns + "/rgb/image_rect_color";
-    string topic_camera_info = cam_ns + "/rgb/camera_info";
+    string topic_camera_info = cam_ns + "/depth/camera_info";
    
     // Checking if all config files could be loaded
     if(strcmp(config_file.c_str(),"") == 0) {

--- a/strands_visual_odometry/src/main.cpp
+++ b/strands_visual_odometry/src/main.cpp
@@ -156,9 +156,9 @@ int main(int argc, char **argv)
     private_node_handle_.param("queue_size", queue_size, int(5));
     private_node_handle_.param("camera_namespace", cam_ns, string("/head_xtion"));
 
-    string topic_image_mono = cam_ns + "/rgb/image_rect";
-    string topic_depth_image = cam_ns + "/depth/image_rect";
-    string topic_camera_info = cam_ns + "/rgb/camera_info";
+    string topic_image_mono = cam_ns + "/rgb/image_mono";
+    string topic_depth_image = cam_ns + "/depth/image_rect_meters";
+    string topic_camera_info = cam_ns + "/depth/camera_info";
 
     ROS_DEBUG("visual_odometry: Queue size for synchronisation is set to: %i", queue_size);
 

--- a/strands_visual_odometry/src/main.cpp
+++ b/strands_visual_odometry/src/main.cpp
@@ -156,8 +156,8 @@ int main(int argc, char **argv)
     private_node_handle_.param("queue_size", queue_size, int(5));
     private_node_handle_.param("camera_namespace", cam_ns, string("/head_xtion"));
 
-    string topic_image_mono = cam_ns + "/rgb/image_mono";
-    string topic_depth_image = cam_ns + "/depth/image";
+    string topic_image_mono = cam_ns + "/rgb/image_rect";
+    string topic_depth_image = cam_ns + "/depth/image_rect";
     string topic_camera_info = cam_ns + "/rgb/camera_info";
 
     ROS_DEBUG("visual_odometry: Queue size for synchronisation is set to: %i", queue_size);


### PR DESCRIPTION
- With this pull request the people perception won't work with the standard openni anymore but with the new openni2 wrapper.
- The __robot_.launch files now use the real robot odometry instead of visual odometry which should increase the performance and save computation time.

Drawback: As long as the openni2 wrapper is in the scitos_robot repository, we won't be able to use the standalone version on a different PC than the embedded robot PC because there is no convenient way of installing the wrapper. See issue: https://github.com/strands-project/scitos_robot/issues/33

This pull request fixes issues: #58, #31, #44, #41, and https://github.com/strands-project/scitos_robot/issues/39
