### PR TITLE
Creating a unique id even after restart

### DIFF
--- a/strands_perception_people_launch/README.md
+++ b/strands_perception_people_launch/README.md
@@ -33,7 +33,7 @@ Parameters:
 * `upper_body_image` _default = /upper_body_detector/image_: The detected upper body image
 * `visual_odometry` _default = /visual_odometry/motion_matrix_: The odometry. This takes the real odometry and only follows naming conventions for the ease of use.
 * `pedestrain_array` _default = /pedestrian_tracking/pedestrian_array_: The detected and tracked pedestrians
-* `tf_target_frame` _default = /base_link_: The coordinate system into which the localisations should be transformed
+* `tf_target_frame` _default = /map: The coordinate system into which the localisations should be transformed
 * `pd_localisations` _default = /pedestrian_localisation/localisations_: The pedestrian localisations
 * `pd_marker` _default = /pedestrian_localisation/marker_array_: A marker arry to visualise found people in rviz
 * `log` _default = false_: Log people and robot locations together with tracking and detection results to message_store database into people_perception collection. Disabled by default because if it is enabled the perception is running continuously.
@@ -65,7 +65,7 @@ Parameters:
 * `upper_body_image` _default = /upper_body_detector/image_: The detected upper body image
 * `visual_odometry` _default = /visual_odometry/motion_matrix_: The odometry. This takes the real odometry and only follows naming conventions for the ease of use.
 * `pedestrain_array` _default = /pedestrian_tracking/pedestrian_array_: The detected and tracked pedestrians
-* `tf_target_frame` _default = /base_link_: The coordinate system into which the localisations should be transformed
+* `tf_target_frame` _default = /map: The coordinate system into which the localisations should be transformed
 * `pd_localisations` _default = /pedestrian_localisation/localisations_: The pedestrian localisations
 * `pd_marker` _default = /pedestrian_localisation/marker_array_: A marker arry to visualise found people in rviz
 * `log` _default = false_: Log people and robot locations together with tracking and detection results to message_store database into people_perception collection. Disabled by default because if it is enabled the perception is running continuously.

--- a/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
+++ b/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
@@ -19,7 +19,7 @@
     <arg name="visual_odometry" default="/visual_odometry/motion_matrix" />
     <arg name="pedestrian_array" default="/pedestrian_tracking/pedestrian_array" />
     <arg name="pedestrian_image" default="/pedestrian_tracking/image" />
-    <arg name="tf_target_frame" default="/base_link" />
+    <arg name="tf_target_frame" default="/map" />
     <arg name="pd_localisations" default="/pedestrian_localisation/localisations" />
     <arg name="pd_marker" default="/pedestrian_localisation/marker_array" />
     <arg name="log" default="false" />

--- a/strands_perception_people_launch/launch/pedestrian_tracker_robot_with_HOG.launch
+++ b/strands_perception_people_launch/launch/pedestrian_tracker_robot_with_HOG.launch
@@ -22,7 +22,7 @@
     <arg name="visual_odometry" default="/visual_odometry/motion_matrix" />
     <arg name="pedestrian_array" default="/pedestrian_tracking/pedestrian_array" />
     <arg name="pedestrian_image" default="/pedestrian_tracking/image" />
-    <arg name="tf_target_frame" default="/base_link" />
+    <arg name="tf_target_frame" default="/map" />
     <arg name="pd_localisations" default="/pedestrian_localisation/localisations" />
     <arg name="pd_marker" default="/pedestrian_localisation/marker_array" />
     <arg name="log" default="false" />

--- a/strands_perception_people_utils/scripts/save_locations.py
+++ b/strands_perception_people_utils/scripts/save_locations.py
@@ -7,12 +7,14 @@ import geometry_msgs.msg
 import message_filters
 import tf
 import thread
+import uuid
 
 
 class SaveLocations():
     def __init__(self):
         rospy.logdebug("Intialising logging")
         target_frame = rospy.get_param("~target_frame", "/base_link")
+        self.uuid_key = str(rospy.get_time())
         self.fps = rospy.Rate(25)
         self.source_frame = ""
         self.robot_pose = geometry_msgs.msg.Pose()
@@ -94,7 +96,8 @@ class SaveLocations():
         rospy.logdebug("Person detected. Logging to people_perception collection.")
         insert = strands_perception_people_msgs.msg.Logging()
         insert.header = pl.header
-        insert.ids = pl.ids
+        for id in pl.ids:
+            insert.ids.append(str(uuid.uuid5(uuid.NAMESPACE_DNS, self.uuid_key+str(id))))
         insert.people = pl.poses
         insert.robot = self.robot_pose
         insert.scores = pl.scores


### PR DESCRIPTION
See issue: https://github.com/strands-project/strands_perception_people/issues/70

In order to have a unique id for every person (normally the counter would be reset if the people perception is restarted) I use uuid5 with NAMESPACE_DNS and the system time on start of the logging node plus the tracker id. This is guaranteed to be unique for every detected person if the logging is restarted when the tracker is restarted. The id is saved in the ids array in the logging message. As usual the index of the id corresponds to the index of the other arrays.

I also changed the default traget_frame for tf to `/map` since this is of more use to most of the people.

@kunzel please have a look if this is something you can agree on.

Needs https://github.com/strands-project/strands_msgs/pull/22 to be merged.
