### PR TITLE
Unique ids for ppl tracker, localisation, and logging

### DIFF
--- a/strands_pedestrian_localisation/include/pedestrian_localisation/pedestrianlocalisation.h
+++ b/strands_pedestrian_localisation/include/pedestrian_localisation/pedestrianlocalisation.h
@@ -23,13 +23,23 @@
 #include "strands_perception_people_msgs/UpperBodyDetector.h"
 #include "strands_perception_people_msgs/PedestrianLocations.h"
 
+#define BASE_LINK "/base_link"
+
 class PedestrianLocalisation
 {
 public:
     PedestrianLocalisation();
 
 private:
-    void publishDetections(std_msgs::Header header, std::vector<geometry_msgs::Point> ppl, std::vector<int> ids, std::vector<double> scores, std::vector<double> distances, std::vector<double> angles, double min_dist, double angle);
+    void publishDetections(std_msgs::Header header,
+                           std::vector<geometry_msgs::Point> ppl,
+                           std::vector<int> ids,
+                           std::vector<std::string> uuids,
+                           std::vector<double> scores,
+                           std::vector<double> distances,
+                           std::vector<double> angles,
+                           double min_dist,
+                           double angle);
     void createVisualisation(std::vector<geometry_msgs::Point> points);
     std::vector<double> cartesianToPolar(geometry_msgs::Point point);
     void trackingCallback(const strands_perception_people_msgs::PedestrianTrackingArray::ConstPtr &pta);

--- a/strands_pedestrian_localisation/src/pedestrian_localisation/pedestrianlocalisation.cpp
+++ b/strands_pedestrian_localisation/src/pedestrian_localisation/pedestrianlocalisation.cpp
@@ -61,9 +61,9 @@ void PedestrianLocalisation::publishDetections(
         pose.orientation.w = 1.0;
         result.poses.push_back(pose);
         ROS_DEBUG("publishDetections: Publishing detection: x: %f, y: %f, z: %f",
-                 pose.position.x,
-                 pose.position.y,
-                 pose.position.z);
+                  pose.position.x,
+                  pose.position.y,
+                  pose.position.z);
     }
     result.ids = ids;
     result.uuids = uuids;
@@ -131,13 +131,13 @@ void PedestrianLocalisation::trackingCallback(const strands_perception_people_ms
         strands_perception_people_msgs::PedestrianTracking pt = pta->pedestrians[i];
         if(pt.traj_x.size() && pt.traj_y.size() && pt.traj_z.size()) {
             ROS_DEBUG("trackingCallback: Received: Position world x: %f, y: %f, z: %f",
-                     pt.traj_x[0],
-                     pt.traj_y[0],
-                     pt.traj_z[0]);
+                      pt.traj_x[0],
+                      pt.traj_y[0],
+                      pt.traj_z[0]);
             ROS_DEBUG("trackingCallback: Received: Position cam x: %f, y: %f, z: %f",
-                     pt.traj_x_camera[0],
-                     pt.traj_y_camera[0],
-                     pt.traj_z_camera[0]);
+                      pt.traj_x_camera[0],
+                      pt.traj_y_camera[0],
+                      pt.traj_z_camera[0]);
 
             //Create stamped pose for tf
             geometry_msgs::PoseStamped poseInCamCoords;
@@ -162,9 +162,13 @@ void PedestrianLocalisation::trackingCallback(const strands_perception_people_ms
                 listener->transformPose(BASE_LINK, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInRobotCoords);
 
                 // Transform into given traget frame. Default /map
-                ROS_DEBUG("Transforming received position into %s coordinate system.", target_frame.c_str());
-                listener->waitForTransform(poseInCamCoords.header.frame_id, target_frame, poseInCamCoords.header.stamp, ros::Duration(3.0));
-                listener->transformPose(target_frame, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInTargetCoords);
+                if(strcmp(target_frame.c_str(), BASE_LINK)) {
+                    ROS_DEBUG("Transforming received position into %s coordinate system.", target_frame.c_str());
+                    listener->waitForTransform(poseInCamCoords.header.frame_id, target_frame, poseInCamCoords.header.stamp, ros::Duration(3.0));
+                    listener->transformPose(target_frame, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInTargetCoords);
+                } else {
+                    poseInTargetCoords = poseInRobotCoords;
+                }
             }
             catch(tf::TransformException ex) {
                 ROS_WARN("Failed transform: %s", ex.what());

--- a/strands_pedestrian_tracking/src/main.cpp
+++ b/strands_pedestrian_tracking/src/main.cpp
@@ -13,7 +13,11 @@
 #include <sensor_msgs/CameraInfo.h>
 
 #include <string.h>
+#include <sstream>
 #include <boost/thread.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -55,9 +59,18 @@ Vector< Hypo > HyposAll;
 Detections *det_comb;
 Tracker tracker;
 int cnt = 0;
+double startup_time = 0.0;
+std::string startup_time_str = "";
 
 //CImgDisplay* main_disp;
 CImg<unsigned char> cim(640,480,1,3);
+
+template<typename T>
+std::string num_to_str(T num) {
+    std::stringstream ss;
+    ss << num;
+    return ss.str();
+}
 
 Vector<double> fromCam2World(Vector<double> posInCamera, Camera cam)
 {
@@ -358,6 +371,14 @@ Camera createCamera(Vector<double>& GP,
     return Camera(K, R, t, GP_world);
 }
 
+std::string generateUUID(std::string time, int id) {
+    boost::uuids::uuid dns_namespace_uuid;
+    boost::uuids::name_generator gen(dns_namespace_uuid);
+    time += num_to_str<int>(id);
+
+    return num_to_str<boost::uuids::uuid>(gen(time.c_str()));
+}
+
 void callbackWithoutHOG(const ImageConstPtr &color,
               const CameraInfoConstPtr &info,
               const GroundPlane::ConstPtr &gp,
@@ -421,6 +442,7 @@ void callbackWithoutHOG(const ImageConstPtr &color,
         }
 
         oneHypoMsg.id = hyposMDL(i).getHypoID();
+        oneHypoMsg.uuid = generateUUID(startup_time_str, oneHypoMsg.id);
         oneHypoMsg.score = hyposMDL(i).getScoreMDL();
         oneHypoMsg.speed = hyposMDL(i).getSpeed();
         hyposMDL(i).getDir(dir);
@@ -533,6 +555,7 @@ void callbackWithHOG(const ImageConstPtr &color,
         }
 
         oneHypoMsg.id = hyposMDL(i).getHypoID();
+        oneHypoMsg.uuid = generateUUID(startup_time_str, oneHypoMsg.id);
         oneHypoMsg.score = hyposMDL(i).getScoreMDL();
         oneHypoMsg.speed = hyposMDL(i).getSpeed();
         hyposMDL(i).getDir(dir);
@@ -599,6 +622,9 @@ int main(int argc, char **argv)
     // Set up ROS.
     ros::init(argc, argv, "pedestrian_tracking");
     ros::NodeHandle n;
+
+    startup_time = ros::Time::now().toSec();
+    startup_time_str = num_to_str<double>(startup_time);
 
     // Declare variables that can be modified by launch file or command line.
     int queue_size;

--- a/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
+++ b/strands_perception_people_launch/launch/pedestrian_tracker_robot.launch
@@ -98,7 +98,6 @@
         <arg name="machine" value="$(arg machine)"/>
         <arg name="user" value="$(arg user)"/>
         <arg name="log" value="$(arg log)"/>
-        <arg name="target_frame" value="$(arg tf_target_frame)"/>
     </include>
 
 </launch> 

--- a/strands_perception_people_launch/launch/pedestrian_tracker_robot_with_HOG.launch
+++ b/strands_perception_people_launch/launch/pedestrian_tracker_robot_with_HOG.launch
@@ -115,7 +115,6 @@
         <arg name="machine" value="$(arg machine)"/>
         <arg name="user" value="$(arg user)"/>
         <arg name="log" value="$(arg log)"/>
-        <arg name="target_frame" value="$(arg tf_target_frame)"/>
     </include>
 
 </launch> 

--- a/strands_perception_people_utils/README.md
+++ b/strands_perception_people_utils/README.md
@@ -23,4 +23,3 @@ Run with:
 
 Parameters:
 * `log`: _Default: true_ This convenience parameter allows to start the whole system without logging the data
-* `target_frame`: _Default: /base_link_ The frame for which the tf should be saved. The source frame is taken from the pedestrian tracker messages and this parameter should be set according to the `target_frame` parameter of the `strands_pedestrian_localisation` node to save the correct tf. If you use one of the convenience launch files for the robot from the `strands_perception_people_launch` package, this is taken care of.

--- a/strands_perception_people_utils/launch/logging.launch
+++ b/strands_perception_people_utils/launch/logging.launch
@@ -2,12 +2,10 @@
     <arg name="machine" default="localhost" />
     <arg name="user" default="" />
     <arg name="log" default="true" />
-    <arg name="target_frame" default="/base_link" />
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)" default="true"/>
     
     <node pkg="strands_perception_people_utils" type="save_locations.py" name="save_people_locations" output="screen" if="$(arg log)">
-        <param name="target_frame" value="$(arg target_frame)" type="string"/>
     </node>
 
 </launch> 


### PR DESCRIPTION
This PR addresses: #70 and #72

The tracker now generates the uuid and passes it on to the localisation and logging. It depends on the system time on start of the tracker and the actual tracking id. The uuid is then passed on to the other nodes instead of just generating one in the highest level (the logger).

This PR also fixes the bug of not having the distance and angle of the the detected ppl relative to the robot if the target frame for tf is not base_link. base_link will now always be used for these values and the given target frame will be used for the ppl pose. Logging also stores both tf transformations: depth frame to base_link and depth frame to given target frame.

Needs https://github.com/strands-project/strands_msgs/pull/23 to be merged.
