### PR TITLE
Setting cmake build type of tracker to Release, disabling asserts.

### DIFF
--- a/strands_pedestrian_tracking/CMakeLists.txt
+++ b/strands_pedestrian_tracking/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(catkin REQUIRED COMPONENTS cv_bridge message_filters roscpp sensor_
 find_package(Qt4 REQUIRED COMPONENTS QtCore QtGui)
 include(${QT_USE_FILE})
 
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE Release)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "-O3")        ## Optimize


### PR DESCRIPTION
"Fixing": #73
Like all the other nodes, this one now also ignores assert errors. Shouldn't have any negative effects.
