### PR TITLE
Removing bayestracking submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bayestracking"]
-	path = bayestracking
-	url = https://github.com/LCAS/bayestracking.git

--- a/strands_people_tracker/CMakeLists.txt
+++ b/strands_people_tracker/CMakeLists.txt
@@ -5,7 +5,7 @@ project(strands_people_tracker)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-    bayestracking
+    bayes_tracking
     geometry_msgs
     roscpp
     std_msgs
@@ -56,7 +56,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES strands_pedestrian_localisation
-  CATKIN_DEPENDS bayestracking geometry_msgs roscpp strands_perception_people_msgs tf
+  CATKIN_DEPENDS bayes_tracking geometry_msgs roscpp strands_perception_people_msgs tf
 #  DEPENDS system_lib
 )
 

--- a/strands_people_tracker/README.md
+++ b/strands_people_tracker/README.md
@@ -1,5 +1,5 @@
 ## People Tracker
-This package uses the bayes_tracking library developed by Nicola Bellotto (University of Lincoln). A catkinized version can be found [here](https://github.com/LCAS/bayes_tracking/tree/catkin-devel) and is also included as a submodule into this repository.
+This package uses the bayes_tracking library developed by Nicola Bellotto (University of Lincoln). A catkinized version can be found [here](https://github.com/LCAS/bayes_tracking/tree/catkin-devel) and from the STRANDS ppa.
 
 The people_tracker uses a single config file to add an arbitrary amount of detectors. The file `config/detectors.yaml` contains the necessary information for the upper_body_detector and the ROS leg_detector (see `to_pose_array` in strands_perception_people_utils/README.md):
 

--- a/strands_people_tracker/README.md
+++ b/strands_people_tracker/README.md
@@ -1,5 +1,5 @@
 ## People Tracker
-This package uses the bayestracking library developed by Nicola Bellotto (University of Lincoln). A catkinized version can be found [here](https://github.com/LCAS/bayestracking/tree/catkin-devel) and is also included as a submodule into this repository.
+This package uses the bayes_tracking library developed by Nicola Bellotto (University of Lincoln). A catkinized version can be found [here](https://github.com/LCAS/bayes_tracking/tree/catkin-devel) and is also included as a submodule into this repository.
 
 The people_tracker uses a single config file to add an arbitrary amount of detectors. The file `config/detectors.yaml` contains the necessary information for the upper_body_detector and the ROS leg_detector (see `to_pose_array` in strands_perception_people_utils/README.md):
 

--- a/strands_people_tracker/include/people_tracker/simple_tracking.h
+++ b/strands_people_tracker/include/people_tracker/simple_tracking.h
@@ -24,9 +24,9 @@
 #include <ros/ros.h>
 #include <ros/time.h>
 #include <geometry_msgs/Point.h>
-#include <bayestracking/multitracker.h>
-#include <bayestracking/models.h>
-#include <bayestracking/ekfilter.h>
+#include <bayes_tracking/multitracker.h>
+#include <bayes_tracking/models.h>
+#include <bayes_tracking/ekfilter.h>
 #include <cstdio>
 #include <boost/thread.hpp>
 #include <boost/thread/mutex.hpp>

--- a/strands_people_tracker/package.xml
+++ b/strands_people_tracker/package.xml
@@ -40,14 +40,14 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>bayestracking</build_depend>
+  <build_depend>bayes_tracking</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>strands_perception_people_msgs</build_depend>
   <build_depend>tf</build_depend>
-  <run_depend>bayestracking</run_depend>
+  <run_depend>bayes_tracking</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
As the bayestracking library is now available from our ppa server (`apt-get install ros-hydro-bayes-tracking`) and included in our rosdep definitions (as `bayes_tracking`) it is no longer needed as a submodule and the branch it is cloned from is deprecated.

If the local environment has been set-up correctly, following the [guide](https://github.com/strands-project/strands_management/wiki/STRANDS-release-procedures) by @marc-hanheide, it will be installed via rosdep.

**_This PR requires that people set-up their local environments using the correct ppa and rosdep definitions. Otherwise the build will fail.**_
