### PR TITLE
Fixing an issue with one of the association algorithms in the bayestracking library

### DIFF
--- a/strands_people_tracker/README.md
+++ b/strands_people_tracker/README.md
@@ -15,7 +15,7 @@ strands_people_tracker:
                 position:                                      # The std deviation for the cartesian model
                     x: 1.2
                     y: 1.2
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, JPDA = Joint Probability Data Association, NNJPDA = NN + JPDA
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
         leg_detector:                                          # Name of detector (used internally to identify them. Has to be unique.
             topic: "/to_pose_array/leg_detector" # The topic on which the geometry_msgs/PoseArray is published
             noise_model:
@@ -25,7 +25,7 @@ strands_people_tracker:
                 position:                                      # The std deviation for the cartesian model
                     x: 0.2
                     y: 0.2
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, JPDA = Joint Probability Data Association, NNJPDA = NN + JPDA
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
 ```
 
 New detectors are added under the parameter namespace `strands_people_tracker/detectors`. Let's have a look at the upper body detector as an example:
@@ -37,8 +37,7 @@ New detectors are added under the parameter namespace `strands_people_tracker/de
  * `position` specifies the standard deviation of x and y in the cartesian model in meters.
 * `matching_algorithm` specifies the algorithm used to match detections from different sensors/detectors. Currently there are three different algorithms which are based on the Mahalanobis distance of the detections (default being NNJPDA if parameter is misspelled):
  * NN: Nearest Neighbour
- * JPDA: Joint Probability Data Association
- * NNJPDA: NN + JPDA
+ * NNJPDA: NN + Joint Probability Data Association
 
 All of these are just normal ROS parameters and can be either specified by the parameter server or using the yaml file in the provided launch file.
 

--- a/strands_people_tracker/config/detectors.yaml
+++ b/strands_people_tracker/config/detectors.yaml
@@ -9,7 +9,7 @@ strands_people_tracker:
                 position:                                      # The std deviation for the cartesian model
                     x: 1.2
                     y: 1.2
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, JPDA = Joint Probability Data Association, NNJPDA = NN + JPDA
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
         leg_detector:                                          # Name of detector (used internally to identify them. Has to be unique.
             topic: "/to_pose_array/leg_detector"               # The topic on which the geometry_msgs/PoseArray is published
             noise_model:
@@ -19,4 +19,4 @@ strands_people_tracker:
                 position:                                      # The std deviation for the cartesian model
                     x: 0.2
                     y: 0.2
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, JPDA = Joint Probability Data Association, NNJPDA = NN + JPDA
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association

--- a/strands_people_tracker/include/people_tracker/asso_exception.h
+++ b/strands_people_tracker/include/people_tracker/asso_exception.h
@@ -1,0 +1,15 @@
+#ifndef ASSO_EXCEPTION_H
+#define ASSO_EXCEPTION_H
+
+#include <exception>
+using namespace std;
+
+class asso_exception: public exception
+{
+  virtual const char* what() const throw()
+  {
+    return "Unknown association algorithm!";
+  }
+};
+
+#endif // ASSO_EXCEPTION_H

--- a/strands_people_tracker/include/people_tracker/people_tracker.h
+++ b/strands_people_tracker/include/people_tracker/people_tracker.h
@@ -30,6 +30,7 @@
 #include "strands_perception_people_msgs/PeopleTracker.h"
 
 #include "people_tracker/simple_tracking.h"
+#include "people_tracker/asso_exception.h"
 
 #define BASE_LINK "/base_link"
 


### PR DESCRIPTION
The bayestracking library offered three association algorithms: NN, JPDA and NNJPDA.

JPDA however was not defined in the code any more and is just a relic from past development processes.
The README and config file now reflect that only NN and NNJPDA are available.
Also, the people tracker is now checking if a valid algorithm was defined in the config file instead of just using NNJPDA if it is not NN or JPDA.
