### PR TITLE
Make the linker happy.

### DIFF
--- a/strands_head_orientation/CMakeLists.txt
+++ b/strands_head_orientation/CMakeLists.txt
@@ -5,6 +5,7 @@ project(strands_head_orientation)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+    mongodb_store   # NEEDS to come early, else the linker will insult you.
     cv_bridge
     geometry_msgs
     image_transport
@@ -12,8 +13,6 @@ find_package(catkin REQUIRED COMPONENTS
     roscpp
     std_msgs
     message_generation
-    mongodb_store_msgs
-    mongodb_store
     opencv_warco
 )
 

--- a/strands_head_orientation/CMakeLists.txt
+++ b/strands_head_orientation/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
     std_msgs
     message_generation
     opencv_warco
+    upper_body_detector
 )
 
 ## System dependencies are found with CMake's conventions

--- a/strands_head_orientation/package.xml
+++ b/strands_head_orientation/package.xml
@@ -7,13 +7,13 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="beyer@todo.todo">beyer</maintainer>
+  <maintainer email="beyer@vision.rwth-aachen.de">Lucas Beyer</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <license>MIT</license>
 
 
   <!-- Url tags are optional, but mutiple are allowed, one per tag -->

--- a/strands_head_orientation/package.xml
+++ b/strands_head_orientation/package.xml
@@ -47,6 +47,7 @@
   <build_depend>message_filters</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>mongodb_store</build_depend>
   <build_depend>mongodb_store_msgs</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -55,6 +56,7 @@
   <run_depend>message_filters</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>mongodb_store</run_depend>
   <run_depend>mongodb_store_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/strands_head_orientation/package.xml
+++ b/strands_head_orientation/package.xml
@@ -49,6 +49,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>mongodb_store</build_depend>
   <build_depend>mongodb_store_msgs</build_depend>
+  <build_depend>upper_body_detector</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>geometry_msgs</run_depend>


### PR DESCRIPTION
Longer explanation: the mongodb_store links to static libmongoclient.a which needs dynamic libboost-filesystem-mt.so.
The problem is another component links to that boost one too, earlier. So CMake doesn't add that into the linker line
later when mongodb_store kicks in. Moving it to the front fixes it, even though it's not clean.
