### PR TITLE
Making camera topic reconfigurable

### DIFF
--- a/ground_plane_estimation/README.md
+++ b/ground_plane_estimation/README.md
@@ -12,6 +12,8 @@ Parameters for estimation:
 * `queue_size` _default = 5_: The synchronisation queue size
 * `config_file` _default = ""_: The global config file. Can be found in ground_plane_estimation/config
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
+* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
 * `ground_plane` _default = /ground_plane_: The estimated ground plane
 
 Parameters for the fixed ground plane:

--- a/ground_plane_estimation/launch/ground_plane_estimated.launch
+++ b/ground_plane_estimation/launch/ground_plane_estimated.launch
@@ -5,6 +5,8 @@
 
     <arg name="queue_size" default="5" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="machine" default="localhost" />
     <arg name="user" default="" />
@@ -14,6 +16,8 @@
     <node pkg="ground_plane_estimation" type="ground_plane_estimated" name="ground_plane" output="log">
         <param name="queue_size" value="$(arg queue_size)" type="int"/>
         <param name="camera_namespace" value="$(arg camera_namespace)" type="string"/>
+        <param name="depth_image" value="$(arg depth_image)" type="string"/>
+        <param name="camera_info_rgb" value="$(arg camera_info_rgb)" type="string"/>
         <param name="ground_plane" value="$(arg ground_plane)" type="string"/>
     </node>
 

--- a/ground_plane_estimation/src/estimated_gp.cpp
+++ b/ground_plane_estimation/src/estimated_gp.cpp
@@ -122,6 +122,8 @@ int main(int argc, char **argv)
     int queue_size;
     string cam_ns;
     string pub_topic_gp;
+    string topic_depth_image;
+    string topic_camera_info;
 
     // Initialize node parameters from launch file or command line.
     // Use a private node handle so that multiple instances of the node can be run simultaneously
@@ -130,8 +132,10 @@ int main(int argc, char **argv)
     private_node_handle_.param("queue_size", queue_size, int(5));
 
     private_node_handle_.param("camera_namespace", cam_ns, string("/head_xtion"));
-    string topic_depth_image = cam_ns + "/depth/image_rect_meters";
-    string topic_camera_info = cam_ns + "/rgb/camera_info";
+    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect_meters"));
+    topic_depth_image = cam_ns + topic_depth_image;
+    private_node_handle_.param("camera_info_rgb", topic_camera_info, string("/rgb/camera_info"));
+    topic_camera_info = cam_ns + topic_camera_info;
 
     ROS_DEBUG("ground_plane: Queue size for synchronisation is set to: %i", queue_size);
 

--- a/mdl_people_tracker/README.md
+++ b/mdl_people_tracker/README.md
@@ -9,6 +9,8 @@ Parameters:
 * `user` _default = ""_: The user used for the ssh connection if machine is not localhost.
 * `queue_size` _default = 20_: The synchronisation queue size
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
+* `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
+* `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
 * `ground_plane` _default = /ground_plane_: The ground plane published by the upper_body_detector
 * `ground_hog` _default = /groundHOG/detections_: The ground_hog detections
 * `upper_body_detections` _default = /upper_body_detector/detections_: The upper_body_detector_detections

--- a/mdl_people_tracker/launch/mdl_people_tracker.launch
+++ b/mdl_people_tracker/launch/mdl_people_tracker.launch
@@ -5,6 +5,8 @@
     
     <arg name="queue_size" default="10" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
     <arg name="visual_odometry" default="/visual_odometry/motion_matrix" />
@@ -22,6 +24,8 @@
     <node pkg="mdl_people_tracker" type="mdl_people_tracker" name="mdl_people_tracker" output="log">
         <param name="queue_size" value="$(arg queue_size)" type="int"/>
         <param name="camera_namespace" value="$(arg camera_namespace)" type="string"/>
+        <param name="rgb_image" value="$(arg rgb_image)" type="string"/>
+        <param name="camera_info_rgb" value="$(arg camera_info_rgb)" type="string"/>
         <param name="ground_plane" value="$(arg ground_plane)" type="string"/>
         <param name="ground_hog" value="" type="string"/> <!-- Important to start without groundHOG -->
         <param name="visual_odometry" value="$(arg visual_odometry)" type="string"/>

--- a/mdl_people_tracker/launch/mdl_people_tracker_with_HOG.launch
+++ b/mdl_people_tracker/launch/mdl_people_tracker_with_HOG.launch
@@ -5,6 +5,8 @@
     
     <arg name="queue_size" default="10" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="ground_hog" default="/groundHOG/detections" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
@@ -23,6 +25,8 @@
     <node pkg="mdl_people_tracker" type="mdl_people_tracker" name="mdl_people_tracker" output="log">
         <param name="queue_size" value="$(arg queue_size)" type="int"/>
         <param name="camera_namespace" value="$(arg camera_namespace)" type="string"/>
+        <param name="rgb_image" value="$(arg rgb_image)" type="string"/>
+        <param name="camera_info_rgb" value="$(arg camera_info_rgb)" type="string"/>
         <param name="ground_plane" value="$(arg ground_plane)" type="string"/>
         <param name="ground_hog" value="$(arg ground_hog)" type="string"/>
         <param name="visual_odometry" value="$(arg visual_odometry)" type="string"/>

--- a/mdl_people_tracker/src/main.cpp
+++ b/mdl_people_tracker/src/main.cpp
@@ -731,8 +731,12 @@ int main(int argc, char **argv)
     private_node_handle_.param("upper_body_detections", topic_upperbody, string("/upper_body_detector/detections"));
     private_node_handle_.param("visual_odometry", topic_vo, string("/visual_odometry/motion_matrix"));
 
-    string topic_color_image = cam_ns + "/rgb/image_rect_color";
-    string topic_camera_info = cam_ns + "/rgb/camera_info";
+    string topic_color_image;
+    private_node_handle_.param("rgb_image", topic_color_image, string("/rgb/image_rect_color"));
+    topic_color_image = cam_ns + topic_color_image;
+    string topic_camera_info;
+    private_node_handle_.param("camera_info_rgb", topic_camera_info, string("/rgb/camera_info"));
+    topic_camera_info = cam_ns + topic_camera_info;
 
     if(!ReadConfigParams(boost::ref(n))) return 1;
     det_comb = new Detections(23, 0);

--- a/perception_people_launch/README.md
+++ b/perception_people_launch/README.md
@@ -25,6 +25,11 @@ Parameters:
 * `pt_queue_size` _default = 10_: The people tracking sync queue size
 * `ptu_state` _default = /ptu/state_: The ptu state topic
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
+* `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
+* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
+* `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
+* `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `ground_plane` _default = /ground_plane_: The fixed ground plane
 * `upper_body_detections` _default = /upper_body_detector/detections_: The detected upper body
 * `upper_body_bb_centres` _default = /upper_body_detector/bounding_box_centres_: Publishing a pose array of the centres of the bounding boxes
@@ -58,6 +63,11 @@ Parameters:
 * `pt_queue_size` _default = 10_: The people tracking sync queue size
 * `ptu_state` _default = /ptu/state_: The ptu state topic
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
+* `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
+* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
+* `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
+* `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `ground_plane` _default = /ground_plane_: The fixed ground plane
 * `upper_body_detections` _default = /upper_body_detector/detections_: The detected upper body
 * `upper_body_bb_centres` _default = /upper_body_detector/bounding_box_centres_: Publishing a pose array of the centres of the bounding boxes
@@ -93,6 +103,11 @@ Parameters:
 * `ubd_queue_size` _default = 5_: The upper body detector sync queue size
 * `pt_queue_size` _default = 10_: The people tracking sync queue size
 * `camera_namespace` _default = /camera_: The camera namespace.
+* `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
+* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
+* `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
+* `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `ground_plane` _default = /ground_plane_: The estimated ground plane
 * `upper_body_detections` _default = /upper_body_detector/detections_: The detected upper body
 * `upper_body_bb_centres` _default = /upper_body_detector/bounding_box_centres_: Publishing a pose array of the centres of the bounding boxes
@@ -123,6 +138,11 @@ Parameters:
 * `ubd_queue_size` _default = 5_: The upper body detector sync queue size
 * `pt_queue_size` _default = 10_: The people tracking sync queue size
 * `camera_namespace` _default = /camera_: The camera namespace.
+* `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
+* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
+* `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
+* `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `ground_plane` _default = /ground_plane_: The estimated ground plane
 * `ground_hog_detections` _default = /groundHOG/detections_: The ground HOG detections
 * `upper_body_detections` _default = /upper_body_detector/detections_: The detected upper body

--- a/perception_people_launch/launch/people_tracker_robot.launch
+++ b/perception_people_launch/launch/people_tracker_robot.launch
@@ -7,6 +7,11 @@
     <arg name="pt_queue_size" default="10" />
     <arg name="ptu_state" default="/ptu/state" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="mono_image" default="/rgb/image_mono" />
+    <arg name="camera_info_rgb" default="/rgb/camera_info" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     /*<arg name="odom" default="/odom" />*/
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
@@ -62,6 +67,9 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg ubd_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
         <arg name="upper_body_bb_centres" value="$(arg upper_body_bb_centres)"/>
         <arg name="upper_body_markers" value="$(arg upper_body_markers)"/>
@@ -76,6 +84,8 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg pt_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
         <arg name="visual_odometry" value="$(arg visual_odometry)"/>

--- a/perception_people_launch/launch/people_tracker_robot_with_HOG.launch
+++ b/perception_people_launch/launch/people_tracker_robot_with_HOG.launch
@@ -8,6 +8,11 @@
     <arg name="pt_queue_size" default="10" />
     <arg name="ptu_state" default="/ptu/state" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="mono_image" default="/rgb/image_mono" />
+    <arg name="camera_info_rgb" default="/rgb/camera_info" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="odom" default="/odom" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="ground_hog_detections" default="/groundHOG/detections" />
@@ -40,6 +45,8 @@
         <arg name="queue_size" value="$(arg gh_queue_size)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="detections" value="$(arg ground_hog_detections)"/>
         <arg name="result_image" value="$(arg ground_hog_image)"/>
     </include>
@@ -78,6 +85,9 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg ubd_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
         <arg name="upper_body_bb_centres" value="$(arg upper_body_bb_centres)"/>
         <arg name="upper_body_image" value="$(arg upper_body_image)"/>
@@ -92,6 +102,8 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg pt_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
         <arg name="ground_hog" value="$(arg ground_hog_detections)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>

--- a/perception_people_launch/launch/people_tracker_standalone.launch
+++ b/perception_people_launch/launch/people_tracker_standalone.launch
@@ -6,6 +6,11 @@
     <arg name="ubd_queue_size" default="5" />
     <arg name="pt_queue_size" default="10" />
     <arg name="camera_namespace" default="/camera" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="mono_image" default="/rgb/image_mono" />
+    <arg name="camera_info_rgb" default="/rgb/camera_info" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
     <arg name="upper_body_bb_centres" default="/upper_body_detector/bounding_box_centres" />
@@ -29,6 +34,9 @@
         <arg name="user" value="$(arg user)"/>
         <arg name="queue_size" value="$(arg vo_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="mono_image" value="$(arg mono_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="motion_parameters" value="$(arg visual_odometry)"/>
     </include>
 
@@ -39,6 +47,8 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg gp_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
     </include>
 
@@ -49,6 +59,9 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg ubd_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
         <arg name="upper_body_bb_centres" value="$(arg upper_body_bb_centres)"/>
         <arg name="upper_body_markers" value="$(arg upper_body_markers)"/>
@@ -63,6 +76,8 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg pt_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
         <arg name="visual_odometry" value="$(arg visual_odometry)"/>

--- a/perception_people_launch/launch/people_tracker_standalone_with_HOG.launch
+++ b/perception_people_launch/launch/people_tracker_standalone_with_HOG.launch
@@ -7,6 +7,11 @@
     <arg name="ubd_queue_size" default="5" />
     <arg name="pt_queue_size" default="10" />
     <arg name="camera_namespace" default="/camera" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="mono_image" default="/rgb/image_mono" />
+    <arg name="camera_info_rgb" default="/rgb/camera_info" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="ground_hog_detections" default="/groundHOG/detections" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
@@ -34,6 +39,8 @@
         <arg name="queue_size" value="$(arg gh_queue_size)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="detections" value="$(arg ground_hog_detections)"/>
         <arg name="result_image" value="$(arg ground_hog_image)"/>
     </include>
@@ -44,6 +51,9 @@
         <arg name="user" value="$(arg user)"/>
         <arg name="queue_size" value="$(arg vo_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="mono_image" value="$(arg mono_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="motion_parameters" value="$(arg visual_odometry)"/>
     </include>
 
@@ -54,6 +64,8 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg gp_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
     </include>
 
@@ -64,6 +76,9 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg ubd_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="depth_image" value="$(arg depth_image)"/>
+        <arg name="camera_info_depth" value="$(arg camera_info_depth)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
         <arg name="upper_body_bb_centres" value="$(arg upper_body_bb_centres)"/>
         <arg name="upper_body_image" value="$(arg upper_body_image)"/>
@@ -78,6 +93,8 @@
         <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
         <arg name="queue_size" value="$(arg pt_queue_size)"/>
         <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+        <arg name="rgb_image" value="$(arg rgb_image)"/>
+        <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
         <arg name="ground_plane" value="$(arg ground_plane)"/>
         <arg name="ground_hog" value="$(arg ground_hog_detections)"/>
         <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>

--- a/strands_ground_hog/README.md
+++ b/strands_ground_hog/README.md
@@ -11,9 +11,9 @@ Parameters:
 * `param_file` _default = $(find strands_ground_hog)/config/ground_hog.yaml_: The config file containing all the essential parameters. Only used if `load_params_from_file == true`.
 * `machine` _default = localhost_: Determines on which machine this node should run.
 * `user` _default = ""_: The user used for the ssh connection if machine is not localhost.
-* `queue_size` _default = 20_: The synchronisation queue size
-* `image_color` _default = /camera/rgb/image_color_: The Kincet colour image
-* `camera_info` _default = /camera/rgb/camera_info_: The Kinect camera info
+* `camera_namespace` _default = /head_xtion_: The camera namespace.
+* `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
+* `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `ground_plane` _default = ""_: The ground plane. Published by upper_body_detector. Will only be used if set. Is used to track speed up detections.
 * `detections` _default = /groundHOG/detections_: The generated data output topic
 * `result_image` _default = /groundHOG/image_: The generated image output topic showing the detections as boundingboxes.

--- a/strands_ground_hog/launch/ground_hog.launch
+++ b/strands_ground_hog/launch/ground_hog.launch
@@ -4,6 +4,8 @@
     <rosparam command="load" file="$(arg param_file)" if="$(arg load_params_from_file)"/>
     
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="detections" default="/groundHOG/detections" />
     <arg name="result_image" default="/groundHOG/image" />
     <arg name="machine" default="localhost" />
@@ -16,6 +18,8 @@
     <node pkg="strands_ground_hog" type="groundHOG" name="ground_hog" output="log">
         <param name="ground_plane" value="" type="string"/>
         <param name="camera_namespace" value="$(arg camera_namespace)" type="string"/>
+        <param name="rgb_image" value="$(arg rgb_image)" type="string"/>
+        <param name="camera_info_depth" value="$(arg camera_info_depth)" type="string"/>
         <param name="detections" value="$(arg detections)" type="string"/>
         <param name="result_image" value="$(arg result_image)" type="string"/>
     </node>

--- a/strands_ground_hog/launch/ground_hog_with_GP.launch
+++ b/strands_ground_hog/launch/ground_hog_with_GP.launch
@@ -6,6 +6,8 @@
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="queue_size" default="10" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="detections" default="/groundHOG/detections" />
     <arg name="result_image" default="/groundHOG/image" />
     <arg name="machine" default="localhost" />
@@ -17,6 +19,8 @@
         <param name="ground_plane" value="$(arg ground_plane)" type="string"/>
         <param name="queue_size" value="$(arg queue_size)" type="int"/>
         <param name="camera_namespace" value="$(arg camera_namespace)" type="string"/>
+        <param name="rgb_image" value="$(arg rgb_image)" type="string"/>
+        <param name="camera_info_depth" value="$(arg camera_info_depth)" type="string"/>
         <param name="detections" value="$(arg detections)" type="string"/>
         <param name="result_image" value="$(arg result_image)" type="string"/>
     </node>

--- a/strands_ground_hog/src/main.cpp
+++ b/strands_ground_hog/src/main.cpp
@@ -286,8 +286,12 @@ int main(int argc, char **argv)
     private_node_handle_.param("camera_namespace", camera_ns, string("/head_xtion"));
     private_node_handle_.param("ground_plane", ground_plane, string(""));
 
-    string image_color = camera_ns + "/rgb/image_rect_color";
-    string camera_info = camera_ns + "/depth/camera_info";
+    string image_color;
+    private_node_handle_.param("rgb_image", image_color, string("/rgb/image_rect_color"));
+    image_color = camera_ns + image_color;
+    string camera_info;
+    private_node_handle_.param("camera_info_depth", camera_info, string("/depth/camera_info"));
+    camera_info = camera_ns + camera_info;
 
     int hog_descriptor_height, hog_descritpor_width, hog_window_height, hog_window_width;
     string model_name;

--- a/upper_body_detector/README.md
+++ b/upper_body_detector/README.md
@@ -12,6 +12,9 @@ Parameters:
 * `config_file` _default = ""_: The global config file. Can be found in strands_upper_bodydetector/config
 * `template_file` _default = ""_: The template file. Can be found in config.
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
+* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
+* `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `ground_plane` _default = /ground_plane_: The estimated/fixed ground plane
 * `upper_body_detections` _default = /upper_body_detector/detections_: The deteced upper bodies
 * `upper_body_bb_centres` _default = /upper_body_detector/bounding_box_centres_: Publishing a pose array of the centres of the bounding boxes

--- a/upper_body_detector/launch/upper_body_detector.launch
+++ b/upper_body_detector/launch/upper_body_detector.launch
@@ -7,6 +7,9 @@
     
     <arg name="queue_size" default="5" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="rgb_image" default="/rgb/image_rect_color" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
     <arg name="upper_body_bb_centres" default="/upper_body_detector/bounding_box_centres" />
     <arg name="upper_body_image" default="/upper_body_detector/image" />
@@ -20,6 +23,9 @@
     <node pkg="upper_body_detector" type="upper_body_detector" name="upper_body_detector" output="log">
         <param name="queue_size" value="$(arg queue_size)" type="int"/>
         <param name="camera_namespace" value="$(arg camera_namespace)" type="string"/>
+        <param name="depth_image" value="$(arg depth_image)" type="string"/>
+        <param name="rgb_image" value="$(arg rgb_image)" type="string"/>
+        <param name="camera_info_depth" value="$(arg camera_info_depth)" type="string"/>
         <param name="upper_body_detections" value="$(arg upper_body_detections)" type="string"/>
         <param name="upper_body_bb_centres" value="$(arg upper_body_bb_centres)" type="string"/>
         <param name="upper_body_image" value="$(arg upper_body_image)" type="string"/>

--- a/upper_body_detector/src/main.cpp
+++ b/upper_body_detector/src/main.cpp
@@ -351,9 +351,15 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    string topic_depth_image = cam_ns + "/depth/image_rect_meters";
-    string topic_color_image = cam_ns + "/rgb/image_rect_color";
-    string topic_camera_info = cam_ns + "/depth/camera_info";
+    string topic_color_image;
+    private_node_handle_.param("rgb_image", topic_color_image, string("/rgb/image_rect_color"));
+    topic_color_image = cam_ns + topic_color_image;
+    string topic_camera_info;
+    private_node_handle_.param("camera_info_depth", topic_camera_info, string("/depth/camera_info"));
+    topic_camera_info = cam_ns + topic_camera_info;
+    string topic_depth_image;
+    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect_meters"));
+    topic_depth_image = cam_ns + topic_depth_image;
 
     // Printing queue size
     ROS_DEBUG("upper_body_detector: Queue size for synchronisation is set to: %i", queue_size);

--- a/visual_odometry/README.md
+++ b/visual_odometry/README.md
@@ -5,6 +5,9 @@ This package calculates the visual odometry using depth and mono images.
 Parameters:
 * `queue_size` _default = 20_: The synchronisation queue size
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
+* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
+* `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `motion_parameters` _default = /visual_odometry/motion_matrix_: The visual odometry
 
 

--- a/visual_odometry/launch/visual_odometry.launch
+++ b/visual_odometry/launch/visual_odometry.launch
@@ -1,6 +1,9 @@
 <launch>
     <arg name="queue_size" default="5" />
     <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="mono_image" default="/rgb/image_mono" />
+    <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="motion_parameters" default="/visual_odometry/motion_matrix" />
     <arg name="machine" default="localhost" />
     <arg name="user" default="" />
@@ -10,6 +13,9 @@
     <node pkg="visual_odometry" type="visual_odometry" name="visual_odometry" output="log">
         <param name="queue_size" value="$(arg queue_size)" type="int"/>
         <param name="camera_namespace" value="$(arg camera_namespace)" type="string"/>
+        <param name="depth_image" value="$(arg depth_image)" type="string"/>
+        <param name="mono_image" value="$(arg mono_image)" type="string"/>
+        <param name="camera_info_depth" value="$(arg camera_info_depth)" type="string"/>
         <param name="motion_parameters" value="$(arg motion_parameters)" type="string"/>
     </node>
 </launch> 

--- a/visual_odometry/src/main.cpp
+++ b/visual_odometry/src/main.cpp
@@ -156,9 +156,15 @@ int main(int argc, char **argv)
     private_node_handle_.param("queue_size", queue_size, int(5));
     private_node_handle_.param("camera_namespace", cam_ns, string("/head_xtion"));
 
-    string topic_image_mono = cam_ns + "/rgb/image_mono";
-    string topic_depth_image = cam_ns + "/depth/image_rect_meters";
-    string topic_camera_info = cam_ns + "/depth/camera_info";
+    string topic_image_mono;
+    private_node_handle_.param("mono_image", topic_image_mono, string("/rgb/image_mono"));
+    topic_image_mono = cam_ns + topic_image_mono;
+    string topic_camera_info;
+    private_node_handle_.param("camera_info_depth", topic_camera_info, string("/depth/camera_info"));
+    topic_camera_info = cam_ns + topic_camera_info;
+    string topic_depth_image;
+    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect_meters"));
+    topic_depth_image = cam_ns + topic_depth_image;
 
     ROS_DEBUG("visual_odometry: Queue size for synchronisation is set to: %i", queue_size);
 


### PR DESCRIPTION
So far only the camera namespace was configurable but that introduced an implicit dependency on the openni_wrapper.
With these changes the whole topic is reconfigurable via a parameter, e.g.:

```
camera_namespace:=/my_cam
depth_image:=/depth/image
```

results in `/my_cam/depth/image` as a topic for the depth image. So `camera_namespace` + `depth_image` = the topic on which to look for the depth image.
