### PR TITLE
Fix for boundig box scaling issue.

### DIFF
--- a/upper_body_detector/src/ROI.cpp
+++ b/upper_body_detector/src/ROI.cpp
@@ -145,8 +145,8 @@ bool ROI::GetRegion2D(Vector<double>& bbox, const Camera& camera, const PointClo
     // Check Height
     if(bbox(3) <= 0)
         return false;
-    else if(bbox(3) >= Globals::dImHeight)
-        bbox(3) = Globals::dImHeight - 1;
+//    else if(bbox(3) >= Globals::dImHeight)
+//        bbox(3) = Globals::dImHeight - 1;
 
     return true;
 }


### PR DESCRIPTION
This fixes a critical error where the bounding box was limited to 159x159 pixels. 

Fairly easy fix. Nothing to say really. However pay attention, if you use the upper body detector, bounding boxes are not guaranteed to be within the image. The nice thing is though, if you multiply the height with 3, you get a full body bounding box. 
