### PR TITLE
Publishing people_msgs/People and adding orientation.

### DIFF
--- a/bayes_people_tracker/CMakeLists.txt
+++ b/bayes_people_tracker/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
     bayes_tracking
     geometry_msgs
     message_generation
+    people_msgs
     roscpp
     std_msgs
     tf

--- a/bayes_people_tracker/include/people_tracker/people_tracker.h
+++ b/bayes_people_tracker/include/people_tracker/people_tracker.h
@@ -13,6 +13,8 @@
 #include <visualization_msgs/MarkerArray.h>
 #include <visualization_msgs/Marker.h>
 #include <std_msgs/ColorRGBA.h>
+#include <people_msgs/People.h>
+#include <people_msgs/Person.h>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -40,15 +42,17 @@ private:
     void trackingThread();
     void publishDetections(bayes_people_tracker::PeopleTracker msg);
     void publishDetections(geometry_msgs::PoseStamped msg);
+    void publishDetections(people_msgs::People msg);
     void publishDetections(double time_sec,
-                           geometry_msgs::Point closest,
-                           std::vector<geometry_msgs::Point> ppl,
+                           geometry_msgs::Pose closest,
+                           std::vector<geometry_msgs::Pose> ppl,
+                           std::vector<geometry_msgs::Pose> vels,
                            std::vector<std::string> uuids,
                            std::vector<double> distances,
                            std::vector<double> angles,
                            double min_dist,
                            double angle);
-    void createVisualisation(std::vector<geometry_msgs::Point> points, ros::Publisher& pub);
+    void createVisualisation(std::vector<geometry_msgs::Pose> points, ros::Publisher& pub);
     std::vector<double> cartesianToPolar(geometry_msgs::Point point);
     void detectorCallback(const geometry_msgs::PoseArray::ConstPtr &pta, string detector);
     void connectCallback(ros::NodeHandle &n);
@@ -183,6 +187,7 @@ private:
 
     ros::Publisher pub_detect;
     ros::Publisher pub_pose;
+    ros::Publisher pub_people;
     ros::Publisher pub_marker;
     tf::TransformListener* listener;
     std::string target_frame;

--- a/bayes_people_tracker/package.xml
+++ b/bayes_people_tracker/package.xml
@@ -18,6 +18,7 @@
   <build_depend>bayes_tracking</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>people_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
@@ -27,6 +28,7 @@
   <run_depend>bayes_tracking</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>people_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>


### PR DESCRIPTION
Closes #143, #38 
- The bayes tracker is now publishing a `people_msgs/People` message which can be used for the social navigation layer.
- The orientation of the person has been added to all published messages that allow for orientation information. The visualisation has not been adapted yet, but showing a Pose of the closest person in rviz, shows that the orientation is now correctly calculated. **Know issues:** for standing people the orientation is not well defined.

All of this has only been tested in simulation so far.
