### PR TITLE
Bayes tracker visualisation improvements and making the mdl tracker optional.

### DIFF
--- a/bayes_people_tracker/README.md
+++ b/bayes_people_tracker/README.md
@@ -61,6 +61,9 @@ Parameters:
 
 * `target_frame`: _Default: /base_link_:the tf frame in which the tracked poses will be published. 
 * `position`: _Default: /people_tracker/positions_: The topic under which the results are published as bayes_people_tracker/PeopleTracker`
+* `pose`: _Default: /people_tracker/pose_: The topic under which the closest detected person is published as a geometry_msgs/PoseStamped`
+* `pose_array`: _Default: /people_tracker/pose_array_: The topic under which the detections are published as a geometry_msgs/PoseArray`
+* `poeple`: _Default: /people_tracker/people_: The topic under which the results are published as people_msgs/People`
 * `marker`: _Default /people_tracker/marker_array_: A visualisation marker array.
 
 You can run the node with:

--- a/bayes_people_tracker/include/people_tracker/people_tracker.h
+++ b/bayes_people_tracker/include/people_tracker/people_tracker.h
@@ -4,6 +4,7 @@
 #include <ros/ros.h>
 #include <ros/time.h>
 #include <tf/transform_listener.h>
+#include <tf/transform_datatypes.h>
 #include <geometry_msgs/Quaternion.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/PoseArray.h>
@@ -42,6 +43,7 @@ private:
     void trackingThread();
     void publishDetections(bayes_people_tracker::PeopleTracker msg);
     void publishDetections(geometry_msgs::PoseStamped msg);
+    void publishDetections(geometry_msgs::PoseArray msg);
     void publishDetections(people_msgs::People msg);
     void publishDetections(double time_sec,
                            geometry_msgs::Pose closest,
@@ -63,6 +65,31 @@ private:
         time += num_to_str<long>(id);
 
         return num_to_str<boost::uuids::uuid>(gen(time.c_str()));
+    }
+
+    geometry_msgs::Point generate_position(geometry_msgs::Point centre, double angle, double dx, double dy)
+    {
+      float s = sin(angle);
+      float c = cos(angle);
+
+      // rotate point
+      geometry_msgs::Point res;
+      res.x = dx * c - dy * s;
+      res.y = dx * s + dy * c;
+
+      // translate point back:
+      res.x += centre.x;
+      res.y += centre.y;
+      res.z  = centre.z;
+      return res;
+    }
+
+    geometry_msgs::Pose generate_extremity_position(geometry_msgs::Pose centre, double dx, double dy, double z) {
+        double angle = tf::getYaw(centre.orientation) + M_PI/2;
+        geometry_msgs::Point p = centre.position;
+        p.z = z;
+        centre.position = generate_position(p, angle, dx, dy);
+        return centre;
     }
 
     visualization_msgs::Marker createMarker(
@@ -135,11 +162,8 @@ private:
         color.r = 0.0F/255.0F;
         color.g = 0.0F/255.0F;
         color.b = 139.0F/255.0F;
-        pose.position.z = 0.4;
-        pose.position.x += 0.1;
-        legs.push_back(createMarker(idl, visualization_msgs::Marker::CYLINDER, action, pose, scale, color));
-        pose.position.x -= 0.2;
-        legs.push_back(createMarker(idr, visualization_msgs::Marker::CYLINDER, action, pose, scale, color));
+        legs.push_back(createMarker(idl, visualization_msgs::Marker::CYLINDER, action, generate_extremity_position(pose, 0.1, 0.0, 0.4), scale, color));
+        legs.push_back(createMarker(idr, visualization_msgs::Marker::CYLINDER, action, generate_extremity_position(pose, -0.1, 0.0, 0.4), scale, color));
         return legs;
     }
 
@@ -157,11 +181,8 @@ private:
         color.r = 139.0F/255.0F;
         color.g = 0.0F/255.0F;
         color.b = 0.0F/255.0F;
-        pose.position.z = 1.1;
-        pose.position.x += 0.2;
-        arms.push_back(createMarker(idl, visualization_msgs::Marker::CYLINDER, action, pose, scale, color));
-        pose.position.x -= 0.4;
-        arms.push_back(createMarker(idr, visualization_msgs::Marker::CYLINDER, action, pose, scale, color));
+        arms.push_back(createMarker(idl, visualization_msgs::Marker::CYLINDER, action, generate_extremity_position(pose, 0.2, 0.0, 1.1), scale, color));
+        arms.push_back(createMarker(idr, visualization_msgs::Marker::CYLINDER, action, generate_extremity_position(pose, -0.2, 0.0, 1.1), scale, color));
         return arms;
     }
 
@@ -187,6 +208,7 @@ private:
 
     ros::Publisher pub_detect;
     ros::Publisher pub_pose;
+    ros::Publisher pub_pose_array;
     ros::Publisher pub_people;
     ros::Publisher pub_marker;
     tf::TransformListener* listener;

--- a/bayes_people_tracker/launch/people_tracker.launch
+++ b/bayes_people_tracker/launch/people_tracker.launch
@@ -4,6 +4,9 @@
 
     <arg name="target_frame" default="/base_link" />
     <arg name="positions" default="/people_tracker/positions" />
+    <arg name="pose" default="/people_tracker/pose" />
+    <arg name="pose_array" default="/people_tracker/pose_array" />
+    <arg name="people" default="/people_tracker/people" />
     <arg name="marker" default="/people_tracker/marker_array" />
     <arg name="machine" default="localhost" />
     <arg name="user" default="" />
@@ -13,6 +16,9 @@
     <node pkg="bayes_people_tracker" type="bayes_people_tracker" name="bayes_people_tracker" output="screen">
         <param name="target_frame" value="$(arg target_frame)" type="string"/>
         <param name="positions" value="$(arg positions)" type="string"/>
+        <param name="pose" value="$(arg pose)" type="string"/>
+        <param name="pose_array" value="$(arg pose_array)" type="string"/>
+        <param name="people" value="$(arg people)" type="string"/>
         <param name="marker" value="$(arg marker)" type="string"/>
     </node>
 

--- a/bayes_people_tracker/src/people_tracker/people_tracker.cpp
+++ b/bayes_people_tracker/src/people_tracker/people_tracker.cpp
@@ -266,9 +266,11 @@ void PeopleTracker::detectorCallback(const geometry_msgs::PoseArray::ConstPtr &p
 void PeopleTracker::connectCallback(ros::NodeHandle &n) {
     bool loc = pub_detect.getNumSubscribers();
     bool markers = pub_marker.getNumSubscribers();
-    bool test_markers = pub_marker.getNumSubscribers();
+    bool people = pub_people.getNumSubscribers();
+    bool pose = pub_pose.getNumSubscribers();
+    bool pose_array = pub_pose_array.getNumSubscribers();
     std::map<std::pair<std::string, std::string>, ros::Subscriber>::const_iterator it;
-    if(!loc && !markers && !test_markers) {
+    if(!loc && !markers && !people && !pose && !pose_array) {
         ROS_DEBUG("Pedestrian Localisation: No subscribers. Unsubscribing.");
         for(it = subscribers.begin(); it != subscribers.end(); ++it)
             const_cast<ros::Subscriber&>(it->second).shutdown();

--- a/bayes_people_tracker/src/people_tracker/people_tracker.cpp
+++ b/bayes_people_tracker/src/people_tracker/people_tracker.cpp
@@ -16,6 +16,7 @@ PeopleTracker::PeopleTracker() :
     std::string pta_topic;
     std::string pub_topic;
     std::string pub_topic_pose;
+    std::string pub_topic_pose_array;
     std::string pub_topic_people;
     std::string pub_marker_topic;
 
@@ -34,6 +35,8 @@ PeopleTracker::PeopleTracker() :
     pub_detect = n.advertise<bayes_people_tracker::PeopleTracker>(pub_topic.c_str(), 10, con_cb, con_cb);
     private_node_handle.param("pose", pub_topic_pose, std::string("/people_tracker/pose"));
     pub_pose = n.advertise<geometry_msgs::PoseStamped>(pub_topic_pose.c_str(), 10, con_cb, con_cb);
+    private_node_handle.param("pose_array", pub_topic_pose_array, std::string("/people_tracker/pose_array"));
+    pub_pose_array = n.advertise<geometry_msgs::PoseArray>(pub_topic_pose_array.c_str(), 10, con_cb, con_cb);
     private_node_handle.param("people", pub_topic_people, std::string("/people_tracker/people"));
     pub_people = n.advertise<people_msgs::People>(pub_topic_people.c_str(), 10, con_cb, con_cb);
     private_node_handle.param("marker", pub_marker_topic, std::string("/people_tracker/marker_array"));
@@ -139,6 +142,11 @@ void PeopleTracker::publishDetections(
     pose.pose = closest;
     publishDetections(pose);
 
+    geometry_msgs::PoseArray poses;
+    poses.header = result.header;
+    poses.poses = ppl;
+    publishDetections(poses);
+
     people_msgs::People people;
     people.header = result.header;
     for(int i = 0; i < ppl.size(); i++) {
@@ -160,6 +168,10 @@ void PeopleTracker::publishDetections(bayes_people_tracker::PeopleTracker msg) {
 
 void PeopleTracker::publishDetections(geometry_msgs::PoseStamped msg) {
     pub_pose.publish(msg);
+}
+
+void PeopleTracker::publishDetections(geometry_msgs::PoseArray msg) {
+    pub_pose_array.publish(msg);
 }
 
 void PeopleTracker::publishDetections(people_msgs::People msg) {

--- a/perception_people_launch/README.md
+++ b/perception_people_launch/README.md
@@ -36,13 +36,17 @@ Parameters:
 * `upper_body_markers default = /upper_body_detector/marker_array_: A visualisation array for rviz
 * `upper_body_image` _default = /upper_body_detector/image_: The detected upper body image
 * `visual_odometry` _default = /visual_odometry/motion_matrix_: The odometry. This takes the real odometry and only follows naming conventions for the ease of use.
-* `pedestrain_array` _default = /mdl_people_tracker/people_array_: The detected and tracked people
-* `people_markers" default="/mdl_people_tracker/marker_array_: A visualisation array for rviz
-* `people_poses" default = /mdl_people_tracker/pose_array_: A PoseArray of the detected people
+* `mdl_people_array` _default = /mdl_people_tracker/people_array_: The detected and tracked people
+* `mdl_people_markers" default="/mdl_people_tracker/marker_array_: A visualisation array for rviz
+* `mdl_people_poses" default = /mdl_people_tracker/pose_array_: A PoseArray of the detected people
 * `tf_target_frame` _default = /map: The coordinate system into which the localisations should be transformed
-* `pd_positions` _default = /people_tracker/positions_: The poses of the tracked people
+* `bayes_people_positions` _default = /people_tracker/positions_: The poses of the tracked people
+* `bayes_people_pose`: _Default: /people_tracker/pose_: The topic under which the closest detected person is published as a geometry_msgs/PoseStamped`
+* `bayes_people_pose_array`: _Default: /people_tracker/pose_array_: The topic under which the detections are published as a geometry_msgs/PoseArray`
+* `bayes_people_poeple`: _Default: /people_tracker/people_: The topic under which the results are published as people_msgs/People`
 * `pd_marker` _default = /people_tracker/marker_array_: A marker arry to visualise found people in rviz
 * `log` _default = false_: Log people and robot locations together with tracking and detection results to message_store database into people_perception collection. Disabled by default because if it is enabled the perception is running continuously.
+* `with_mdl_tracker` _default = false_: Starts the mdl people tracker in addition to the bayes tracker
 
 
 Running:

--- a/perception_people_launch/launch/people_tracker_robot.launch
+++ b/perception_people_launch/launch/people_tracker_robot.launch
@@ -12,21 +12,25 @@
     <arg name="mono_image" default="/rgb/image_mono" />
     <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="camera_info_depth" default="/depth/camera_info" />
-    /*<arg name="odom" default="/odom" />*/
+    <arg name="odom" default="/odom" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />
     <arg name="upper_body_bb_centres" default="/upper_body_detector/bounding_box_centres" />
     <arg name="upper_body_markers" default="/upper_body_detector/marker_array" />
     <arg name="upper_body_image" default="/upper_body_detector/image" />
     <arg name="visual_odometry" default="/visual_odometry/motion_matrix" />
-    <arg name="people_array" default="/mdl_people_tracker/people_array" />
-    <arg name="people_markers" default="/mdl_people_tracker/marker_array" />
-    <arg name="people_poses" default="/mdl_people_tracker/pose_array" />
-    <arg name="people_image" default="/mdl_people_tracker/image" />
+    <arg name="mdl_people_array" default="/mdl_people_tracker/people_array" />
+    <arg name="mdl_people_markers" default="/mdl_people_tracker/marker_array" />
+    <arg name="mdl_people_poses" default="/mdl_people_tracker/pose_array" />
+    <arg name="mdl_people_image" default="/mdl_people_tracker/image" />
     <arg name="tf_target_frame" default="/map" />
-    <arg name="pd_positions" default="/people_tracker/positions" />
-    <arg name="pd_marker" default="/people_tracker/marker_array" />
+    <arg name="bayes_people_positions" default="/people_tracker/positions" />
+    <arg name="bayes_people_pose" default="/people_tracker/pose" />
+    <arg name="bayes_people_pose_array" default="/people_tracker/pose_array" />
+    <arg name="bayes_people_people" default="/people_tracker/people" />
+    <arg name="bayes_people_marker" default="/people_tracker/marker_array" />
     <arg name="scan" default="/scan" />
+    <arg name="with_mdl_tracker" default="false"/>
     <arg name="log" default="false" />
 
     <arg name="machine" default="localhost" />
@@ -34,23 +38,6 @@
 
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
     
-    <!-- Visual Odometry 
-    <include file="$(find visual_odometry)/launch/visual_odometry.launch">
-        <arg name="machine" value="$(arg machine)"/>
-        <arg name="user" value="$(arg user)"/>
-        <arg name="queue_size" value="$(arg vo_queue_size)"/>
-        <arg name="camera_namespace" value="$(arg camera_namespace)"/>
-        <arg name="motion_parameters" value="$(arg visual_odometry)"/>
-    </include> -->
-
-    <!-- Odometry -->
-    <include file="$(find odometry_to_motion_matrix)/launch/odom2visual.launch">
-        <arg name="machine" value="$(arg machine)"/>
-        <arg name="user" value="$(arg user)"/>
-        <arg name="odom" value="$(arg odom)"/>
-        <arg name="motion_parameters" value="$(arg visual_odometry)"/>
-    </include>
-
     <!-- Ground Plane - fixed -->
     <include file="$(find ground_plane_estimation)/launch/ground_plane_fixed.launch">
         <arg name="machine" value="$(arg machine)"/>
@@ -77,32 +64,45 @@
         <arg name="ground_plane" value="$(arg ground_plane)"/>
     </include>
 
-    <!-- Pedestrian Tracking -->
-    <include file="$(find mdl_people_tracker)/launch/mdl_people_tracker.launch">
-        <arg name="machine" value="$(arg machine)"/>
-        <arg name="user" value="$(arg user)"/>
-        <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
-        <arg name="queue_size" value="$(arg pt_queue_size)"/>
-        <arg name="camera_namespace" value="$(arg camera_namespace)"/>
-        <arg name="rgb_image" value="$(arg rgb_image)"/>
-        <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
-        <arg name="ground_plane" value="$(arg ground_plane)"/>
-        <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
-        <arg name="visual_odometry" value="$(arg visual_odometry)"/>
-        <arg name="people_array" value="$(arg people_array)"/>
-        <arg name="people_image" value="$(arg people_image)"/>
-        <arg name="people_markers" value="$(arg people_markers)"/>
-        <arg name="people_poses" value="$(arg people_poses)"/>
-        <arg name="target_frame" value="$(arg tf_target_frame)"/>
-    </include>
+    <group if="$(arg with_mdl_tracker)">
+        <!-- Odometry -->
+        <include file="$(find odometry_to_motion_matrix)/launch/odom2visual.launch">
+            <arg name="machine" value="$(arg machine)"/>
+            <arg name="user" value="$(arg user)"/>
+            <arg name="odom" value="$(arg odom)"/>
+            <arg name="motion_parameters" value="$(arg visual_odometry)"/>
+        </include>
+
+        <!-- Pedestrian Tracking -->
+        <include file="$(find mdl_people_tracker)/launch/mdl_people_tracker.launch">
+            <arg name="machine" value="$(arg machine)"/>
+            <arg name="user" value="$(arg user)"/>
+            <arg name="load_params_from_file" value="$(arg load_params_from_file)"/>
+            <arg name="queue_size" value="$(arg pt_queue_size)"/>
+            <arg name="camera_namespace" value="$(arg camera_namespace)"/>
+            <arg name="rgb_image" value="$(arg rgb_image)"/>
+            <arg name="camera_info_rgb" value="$(arg camera_info_rgb)"/>
+            <arg name="ground_plane" value="$(arg ground_plane)"/>
+            <arg name="upper_body_detections" value="$(arg upper_body_detections)"/>
+            <arg name="visual_odometry" value="$(arg visual_odometry)"/>
+            <arg name="people_array" value="$(arg mdl_people_array)"/>
+            <arg name="people_image" value="$(arg mdl_people_image)"/>
+            <arg name="people_markers" value="$(arg mdl_people_markers)"/>
+            <arg name="people_poses" value="$(arg mdl_people_poses)"/>
+            <arg name="target_frame" value="$(arg tf_target_frame)"/>
+        </include>
+    </group>
 
     <!-- People Tracker -->
     <include file="$(find bayes_people_tracker)/launch/people_tracker.launch">
         <arg name="machine" value="$(arg machine)"/>
         <arg name="user" value="$(arg user)"/>
         <arg name="target_frame" value="$(arg tf_target_frame)"/>
-        <arg name="positions" value="$(arg pd_positions)"/>
-        <arg name="marker" value="$(arg pd_marker)"/>
+        <arg name="positions" value="$(arg bayes_people_positions)"/>
+        <arg name="pose" value="$(arg bayes_people_pose)"/>
+        <arg name="pose_array" value="$(arg bayes_people_pose_array)"/>
+        <arg name="people" value="$(arg bayes_people_people)"/>
+        <arg name="marker" value="$(arg bayes_people_marker)"/>
     </include>
 
     <!-- To PoseArray -->


### PR DESCRIPTION
- Publishing a pose array for all detected people to have more generic output
- Added missing bayes tracker parameters to launch files and READMEs. Prefixed mdl tracker parameters to be more specific.
- Starting the mdl tracker is now optional when using the robot launch file. `with_mdl_tracker:=true` starts the mdl tracker in addition to the bayes tracker. Default is `false`
- The stick figure visualisation is now oriented according to the velocity of the tracker
