### PR TITLE
Restructuring tracker parameters, adding Unscented Kalman filter

### DIFF
--- a/bayes_people_tracker/config/detectors.yaml
+++ b/bayes_people_tracker/config/detectors.yaml
@@ -1,22 +1,18 @@
 bayes_people_tracker:
+    filter_type: "UKF"                                         # The Kalman filter type: EKF = Extended Kalman Filter, UKF = Uncented Kalman Filter
+    cv_noise_params:                                           # The noise for the constant velocity prediction model
+        x: 1.4
+        y: 1.4
     detectors:                                                 # Add detectors under this namespace
         upper_body_detector:                                   # Name of detector (used internally to identify them. Has to be unique.
             topic: "/upper_body_detector/bounding_box_centres" # The topic on which the geometry_msgs/PoseArray is published
-            noise_model:
-                velocity:                                      # The std deviation for the constant velocity model
-                    x: 1.4
-                    y: 1.4
-                position:                                      # The std deviation for the cartesian model
-                    x: 1.2
-                    y: 1.2
+            cartesian_noise_params:                            # The noise for the cartesian observation model
+                x: 1.2
+                y: 1.2
             matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
         leg_detector:                                          # Name of detector (used internally to identify them. Has to be unique.
             topic: "/to_pose_array/leg_detector"               # The topic on which the geometry_msgs/PoseArray is published
-            noise_model:
-                velocity:                                      # The std deviation for the constant velocity model
-                    x: 1.4
-                    y: 1.4
-                position:                                      # The std deviation for the cartesian model
-                    x: 0.2
-                    y: 0.2
+            cartesian_noise_params:                            # The noise for the cartesian observation model
+                x: 1.2
+                y: 1.2
             matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association

--- a/bayes_people_tracker/config/detectors.yaml
+++ b/bayes_people_tracker/config/detectors.yaml
@@ -4,15 +4,15 @@ bayes_people_tracker:
         x: 1.4
         y: 1.4
     detectors:                                                 # Add detectors under this namespace
-        upper_body_detector:                                   # Name of detector (used internally to identify them. Has to be unique.
+        upper_body_detector:                                   # Name of detector (used internally to identify them). Has to be unique.
             topic: "/upper_body_detector/bounding_box_centres" # The topic on which the geometry_msgs/PoseArray is published
             cartesian_noise_params:                            # The noise for the cartesian observation model
                 x: 0.5
                 y: 0.5
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
-        leg_detector:                                          # Name of detector (used internally to identify them. Has to be unique.
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN Joint Probability Data Association
+        leg_detector:                                          # Name of detector (used internally to identify them). Has to be unique.
             topic: "/to_pose_array/leg_detector"               # The topic on which the geometry_msgs/PoseArray is published
             cartesian_noise_params:                            # The noise for the cartesian observation model
                 x: 0.2
                 y: 0.2
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN Joint Probability Data Association

--- a/bayes_people_tracker/config/detectors.yaml
+++ b/bayes_people_tracker/config/detectors.yaml
@@ -7,12 +7,12 @@ bayes_people_tracker:
         upper_body_detector:                                   # Name of detector (used internally to identify them. Has to be unique.
             topic: "/upper_body_detector/bounding_box_centres" # The topic on which the geometry_msgs/PoseArray is published
             cartesian_noise_params:                            # The noise for the cartesian observation model
-                x: 1.2
-                y: 1.2
+                x: 0.5
+                y: 0.5
             matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
         leg_detector:                                          # Name of detector (used internally to identify them. Has to be unique.
             topic: "/to_pose_array/leg_detector"               # The topic on which the geometry_msgs/PoseArray is published
             cartesian_noise_params:                            # The noise for the cartesian observation model
-                x: 1.2
-                y: 1.2
+                x: 0.2
+                y: 0.2
             matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association

--- a/bayes_people_tracker/include/people_tracker/asso_exception.h
+++ b/bayes_people_tracker/include/people_tracker/asso_exception.h
@@ -12,4 +12,12 @@ class asso_exception: public exception
   }
 };
 
+class filter_exception: public exception
+{
+  virtual const char* what() const throw()
+  {
+    return "Unknown filter type!";
+  }
+};
+
 #endif // ASSO_EXCEPTION_H

--- a/bayes_people_tracker/include/people_tracker/people_tracker.h
+++ b/bayes_people_tracker/include/people_tracker/people_tracker.h
@@ -222,7 +222,8 @@ private:
 
     boost::uuids::uuid dns_namespace_uuid;
 
-    SimpleTracking<EKFilter> *st;
+    SimpleTracking<EKFilter> *ekf = NULL;
+    SimpleTracking<UKFilter> *ukf = NULL;
     std::map<std::pair<std::string, std::string>, ros::Subscriber> subscribers;
 };
 

--- a/bayes_people_tracker/include/people_tracker/people_tracker.h
+++ b/bayes_people_tracker/include/people_tracker/people_tracker.h
@@ -222,7 +222,7 @@ private:
 
     boost::uuids::uuid dns_namespace_uuid;
 
-    SimpleTracking/*<EKFilter>*/ *st;
+    SimpleTracking<EKFilter> *st;
     std::map<std::pair<std::string, std::string>, ros::Subscriber> subscribers;
 };
 

--- a/bayes_people_tracker/include/people_tracker/people_tracker.h
+++ b/bayes_people_tracker/include/people_tracker/people_tracker.h
@@ -21,6 +21,8 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+#include <bayes_tracking/BayesFilter/bayesFlt.hpp>
+
 #include <XmlRpcValue.h>
 
 #include <string.h>
@@ -220,7 +222,7 @@ private:
 
     boost::uuids::uuid dns_namespace_uuid;
 
-    SimpleTracking *st;
+    SimpleTracking/*<EKFilter>*/ *st;
     std::map<std::pair<std::string, std::string>, ros::Subscriber> subscribers;
 };
 

--- a/bayes_people_tracker/include/people_tracker/simple_tracking.h
+++ b/bayes_people_tracker/include/people_tracker/simple_tracking.h
@@ -75,7 +75,7 @@ bool MTRK::initialize(FilterType* &filter, sequence_t& obsvSeq) {
     return true;
 }
 
-//template<typename FilterType>
+template<typename FilterType>
 class SimpleTracking
 {
 public:
@@ -103,12 +103,12 @@ public:
         time += dt;
         if(track_time) *track_time = time;
 
-        for(/*typename*/ std::map<std::string, detector_model>::const_iterator it = detectors.begin();
+        for(typename std::map<std::string, detector_model>::const_iterator it = detectors.begin();
             it != detectors.end();
             ++it) {
             // prediction
             cvm->update(dt);
-            mtrk./*template */predict<CVModel>(*cvm);
+            mtrk.template predict<CVModel>(*cvm);
 
             // process observations (if available) and update tracks
             mtrk.process(*(it->second.ctm), it->second.alg);
@@ -153,7 +153,7 @@ public:
 
         // prediction
         cvm->update(dt);
-        mtrk./*template */predict<Models::CVModel>(*cvm);
+        mtrk.template predict<CVModel>(*cvm);
 
         mtrk.process(*(det.ctm), det.alg);
 
@@ -171,7 +171,7 @@ private:
     double dt, time;
     boost::mutex mutex;
     CVModel *cvm;                   // CV model
-    MultiTracker<EKFilter, 4> mtrk; // state [x, v_x, y, v_y]
+    MultiTracker<FilterType, 4> mtrk; // state [x, v_x, y, v_y]
 
     typedef struct {
         CartesianModel *ctm;        // Cartesian observation model

--- a/bayes_people_tracker/include/people_tracker/simple_tracking.h
+++ b/bayes_people_tracker/include/people_tracker/simple_tracking.h
@@ -27,6 +27,7 @@
 #include <bayes_tracking/multitracker.h>
 #include <bayes_tracking/models.h>
 #include <bayes_tracking/ekfilter.h>
+#include <bayes_tracking/ukfilter.h>
 #include <cstdio>
 #include <boost/thread.hpp>
 #include <boost/thread/mutex.hpp>
@@ -36,9 +37,6 @@
 using namespace std;
 using namespace MTRK;
 using namespace Models;
-
-
-typedef EKFilter Filter;
 
 // rule to detect lost track
 template<class FilterType>
@@ -77,6 +75,7 @@ bool MTRK::initialize(FilterType* &filter, sequence_t& obsvSeq) {
     return true;
 }
 
+//template<typename FilterType>
 class SimpleTracking
 {
 public:
@@ -85,11 +84,14 @@ public:
         observation = new FM::Vec(2);
     }
 
-    void addDetectorModel(std::string name, association_t alg, double vel_noise_x, double vel_noise_y, double pos_noise_x, double pos_noise_y) {
+    void createConstantVelocityModel(double vel_noise_x, double vel_noise_y) {
+        cvm = new CVModel(vel_noise_x, vel_noise_y);
+    }
+
+    void addDetectorModel(std::string name, association_t alg, double pos_noise_x, double pos_noise_y) {
         ROS_INFO("Adding detector model for: %s.", name.c_str());
         detector_model det;
         det.alg = alg;
-        det.cvm = new CVModel(vel_noise_x, vel_noise_y);
         det.ctm = new CartesianModel(pos_noise_x, pos_noise_y);
         detectors[name] = det;
     }
@@ -101,12 +103,12 @@ public:
         time += dt;
         if(track_time) *track_time = time;
 
-        for(std::map<std::string, detector_model>::const_iterator it = detectors.begin();
+        for(/*typename*/ std::map<std::string, detector_model>::const_iterator it = detectors.begin();
             it != detectors.end();
             ++it) {
             // prediction
-            it->second.cvm->update(dt);
-            mtrk.predict<CVModel>(*(it->second.cvm));
+            cvm->update(dt);
+            mtrk./*template */predict<CVModel>(*cvm);
 
             // process observations (if available) and update tracks
             mtrk.process(*(it->second.ctm), it->second.alg);
@@ -150,8 +152,8 @@ public:
         time += dt;
 
         // prediction
-        det.cvm->update(dt);
-        mtrk.predict<CVModel>(*(det.cvm));
+        cvm->update(dt);
+        mtrk./*template */predict<Models::CVModel>(*cvm);
 
         mtrk.process(*(det.ctm), det.alg);
 
@@ -164,16 +166,17 @@ public:
     }
 
 private:
-    MultiTracker<Filter, 4> mtrk;    // state [x, v_x, y, v_y]
-    FM::Vec *observation;            // observation [x, y]
+
+    FM::Vec *observation;           // observation [x, y]
     double dt, time;
     boost::mutex mutex;
+    CVModel *cvm;                   // CV model
+    MultiTracker<EKFilter, 4> mtrk; // state [x, v_x, y, v_y]
 
-    struct detector_model {
-        CVModel *cvm;               // CV model
+    typedef struct {
         CartesianModel *ctm;        // Cartesian observation model
         association_t alg;          // Data association algorithm
-    };
+    } detector_model;
     std::map<std::string, detector_model> detectors;
 
     double getTime() {

--- a/bayes_people_tracker/src/people_tracker/people_tracker.cpp
+++ b/bayes_people_tracker/src/people_tracker/people_tracker.cpp
@@ -7,7 +7,7 @@ PeopleTracker::PeopleTracker() :
     ros::NodeHandle n;
 
     listener = new tf::TransformListener();
-    st = new SimpleTracking/*<EKFilter>*/();
+    st = new SimpleTracking<EKFilter>();
 
     startup_time = ros::Time::now().toSec();
     startup_time_str = num_to_str<double>(startup_time);

--- a/bayes_people_tracker/src/people_tracker/people_tracker.cpp
+++ b/bayes_people_tracker/src/people_tracker/people_tracker.cpp
@@ -49,7 +49,7 @@ PeopleTracker::PeopleTracker() :
 void PeopleTracker::parseParams(ros::NodeHandle n) {
     std::string filter;
     n.getParam("filter_type", filter);
-    ROS_INFO_STREAM(filter);
+    ROS_INFO_STREAM("Found filter type: " << filter);
     if(filter == "EKF")
         ekf = new SimpleTracking<EKFilter>();
     else if(filter == "UKF")
@@ -62,10 +62,11 @@ void PeopleTracker::parseParams(ros::NodeHandle n) {
     XmlRpc::XmlRpcValue cv_noise;
     n.getParam("cv_noise_params", cv_noise);
     ROS_ASSERT(cv_noise.getType() == XmlRpc::XmlRpcValue::TypeStruct);
-    ROS_INFO_STREAM("Constant Velocity model noise: " << cv_noise);
+    ROS_INFO_STREAM("Constant Velocity Model noise: " << cv_noise);
     ekf == NULL ?
         ukf->createConstantVelocityModel(cv_noise["x"], cv_noise["y"]) :
         ekf->createConstantVelocityModel(cv_noise["x"], cv_noise["y"]);
+    ROS_INFO_STREAM("Created " << filter << " based tracker using constant velocity prediction model.");
 
     XmlRpc::XmlRpcValue detectors;
     n.getParam("detectors", detectors);


### PR DESCRIPTION
The actual structure of the config file was misleading regarding the functionality of the tracker. The Constant Velocity prediction model is of course the same for all the detectors and only the Cartesian observation model is detector specific. Therefore the config file has been adjusted and the code has been changed where necessary.

Additionally, so far only the Extended Kalman Filter was used. Now it is possible to define the filter type at startup and choose from the Extended and the Unscented Kalman filter. In theory, also a particle filter could be used but this is slower than the others and does not yield better results.

Implementation has been tested on Robot.
