### PR TITLE
work towards associating UBD and tracker output

### DIFF
--- a/mdl_people_tracker/include/Detections.h
+++ b/mdl_people_tracker/include/Detections.h
@@ -56,6 +56,10 @@ public:
     double getHeight( int frame,  int detec);
 //    void getDetection(int frame, int detec, Vector<double>& det);
     int getCategory(int frame, int detec);
+    uint32_t getSeqNr(int frame, int detec);
+
+    int getIndex(int frame, int detec);
+
 //    int getDetNumber(int frame, int detec);
 //    Vector<Vector<double> > get3Dpoints(int frame, int detec);
 //    Vector<Vector<int> > getOccCells(int frame, int detec);

--- a/mdl_people_tracker/include/Hypo.h
+++ b/mdl_people_tracker/include/Hypo.h
@@ -147,6 +147,16 @@ public:
     void getStateCovMats(Vector<Matrix<double> >& covMats);
     void setStateCovMats(Vector<Matrix<double> >& covMats);
 
+
+    void pushUbdSeqNr(uint32_t seq);
+
+    void pushUbdIndex(int index);
+
+	const std::vector<int>& getUbdIndex();
+
+	const std::vector<uint32_t>& getUbdSeqNr();
+
+
 //    void setWasApproved(bool v);
 //    bool getWasApproved();
 
@@ -216,6 +226,14 @@ protected:
 
     bool b_terminationFlag;
     int n_lastSelected;
+
+
+    //UBD seq. numbers of messages that were used to make this hypothesis
+    std::vector<uint32_t> ubd_header_seq;
+    //Indices into the arrays in UBD messages. There are stored (among other) coordinates of the people (within camera image)
+    //that were used for the hypothesis.
+    std::vector<int> ubd_index;
+
 
 //    bool was_not_approved;
 

--- a/mdl_people_tracker/msg/MdlPeopleTracker.msg
+++ b/mdl_people_tracker/msg/MdlPeopleTracker.msg
@@ -12,3 +12,5 @@ float64 speed           # Speed of detected person
 int64 id                # Tracking id. Will be reset to 0 after restart
 string uuid             # Unique uuid5 (NAMESPACE_DNS) person id as string. Id is based on system time on start-up and id.
 float64 score           # Tracker confidence
+uint32[] seq            # Seq. numbers from the headers of UBD messages. These identify the UBD messages that were used for a tracker hypothesis.
+int32[] index           # Index for the arrays in a UBD message.

--- a/mdl_people_tracker/src/Detections.cpp
+++ b/mdl_people_tracker/src/Detections.cpp
@@ -92,6 +92,31 @@ Detections::Detections(int x, const int flag)
 
 // ++++++++++++++++++++++++ Implementation ++++++++++++++++++++++++++++++++++++++
 
+/*
+ * Get sequence number from a detection. If the particular detection message was empty, return 0
+ */
+uint32_t Detections::getSeqNr(int frame, int detec){
+    	//cout<<"trying to access frame: "<<frame<<" and detection: "<<detec<<endl;
+
+    	Vector<Vector<double> > v=detC(frame);
+    	int vs = v.getSize();
+
+    	if(detec >= vs || frame >= detC.getSize()){
+    		return 0;
+    	}
+    	return static_cast<unsigned int>(detC(frame)(detec)(24));
+    }
+
+/*
+ * Get index from a detection. If the particular detection message was empty, return -1
+ */
+int Detections::getIndex(int frame, int detec){
+	if(detec >= detC(frame).getSize() || frame >= detC.getSize()){
+		return -1;
+	}
+
+	return static_cast<int>(detC(frame)(detec)(1));
+}
 
 int Detections::numberDetectionsAtFrame(int frame)
 {
@@ -165,7 +190,7 @@ int Detections::prepareDet(Vector<double> &detContent, Vector<Vector <double> >&
     int bbox_hog = 4;
     int distance_z = 8;
 
-    detContent.setSize(24, 0.0);
+    detContent.setSize(25, 0.0);
 
     detContent(score) = det(i)(score_hog);
     detContent(scale) = det(i)(scale_hog) ;
@@ -182,6 +207,11 @@ int Detections::prepareDet(Vector<double> &detContent, Vector<Vector <double> >&
     {
         detContent(22) = 1;
     }
+
+    // det is a vector, that contains the detection messages. Detection message contains the seq # that I want, at index 9
+    // here, I'm saving the number
+    detContent(24) = det(i)(9);
+
 
     Matrix<double> camRot = Eye<double>(3);
     Vector<double> camPos(3, 0.0);
@@ -492,7 +522,8 @@ void Detections::addHOGdetOneFrame(Vector<Vector <double> >& det, int frame, CIm
 
             computeColorHist(colhist, v_bbox, Globals::binSize, imageLeft);
 
-            detC(frame).pushBack(detContent);
+            //ROS_FATAL_STREAM("2) seq number of frame "<< frame <<" saved in detContent:"<<detContent(24));
+            detC(frame).pushBack(detContent); //HERE is the push of the single detection into the vector of all detections.
 
 
             colHists(frame).pushBack(colhist);

--- a/mdl_people_tracker/src/Hypo.cpp
+++ b/mdl_people_tracker/src/Hypo.cpp
@@ -13,6 +13,9 @@ Hypo& Hypo::operator=(const Hypo &hypo)
     if (this == &hypo)
         return *this;
 
+    ubd_header_seq=hypo.ubd_header_seq;
+    ubd_index=hypo.ubd_index;
+
 //    m_mP4D = hypo.m_mP4D;
     m_vvIdxC = hypo.m_vvIdxC;
     m_nCateg = hypo.m_nCateg;
@@ -71,6 +74,8 @@ Hypo::Hypo()
 
 Hypo::Hypo(const Hypo& hypo)
 {
+    ubd_header_seq=hypo.ubd_header_seq;
+    ubd_index=hypo.ubd_index;
 //    m_mP4D = hypo.m_mP4D;
     m_vvIdxC = hypo.m_vvIdxC;
     m_nCateg = hypo.m_nCateg;
@@ -154,6 +159,27 @@ Hypo::~Hypo()
 //{
 //    target = (m_mP4D);
 //}
+
+
+
+/////////////// methods to deal with UBD seq. numbers and indices
+void Hypo::pushUbdSeqNr(uint32_t seq){
+	ubd_header_seq.push_back(seq);
+}
+
+void Hypo::pushUbdIndex(int index){
+	ubd_index.push_back(index);
+}
+
+const std::vector<uint32_t>& Hypo::getUbdSeqNr() {
+	return ubd_header_seq;
+}
+
+const std::vector<int>& Hypo::getUbdIndex() {
+	return ubd_index;
+}
+////////////////////////////////////////////////////////////////////
+
 
 // ***********************************************************************
 //   Idx

--- a/mdl_people_tracker/src/main.cpp
+++ b/mdl_people_tracker/src/main.cpp
@@ -453,7 +453,7 @@ void callbackWithoutHOG(const ImageConstPtr &color,
     Camera camera = createCamera(GP, vo, info);
 
     // Get detections from upper body
-    Vector<double> single_detection(9);
+    Vector<double> single_detection(10);
     Vector<Vector< double > > detected_bounding_boxes;
 
     for(int i = 0; i < upper->pos_x.size(); i++)
@@ -467,15 +467,21 @@ void callbackWithoutHOG(const ImageConstPtr &color,
         single_detection(6) = upper->width[i];
         single_detection(7) = upper->height[i] * 3;
         single_detection(8) = upper->median_depth[i];
+        single_detection(9) = (double) upper->header.seq; // saving the seq. nr.
         detected_bounding_boxes.pushBack(single_detection);
     }
 
     get_image((unsigned char*)(&color->data[0]),info->width,info->height,cim);
-    ///////////////////////////////////////////TRACKING///////////////////////////
 
+
+
+    /////////////////////////////////// TRACKING METHOD //////////////////////////
     tracker.process_tracking_oneFrame(HyposAll, *det_comb, cnt, detected_bounding_boxes, cim, camera);
-    Vector<Hypo> hyposMDL = tracker.getHyposMDL();
+    //////////////////////////////////////////////////////////////////////////////
 
+
+
+    Vector<Hypo> hyposMDL = tracker.getHyposMDL();
 
     MdlPeopleTrackerArray allHypoMsg;
     allHypoMsg.header = upper->header;
@@ -504,6 +510,13 @@ void callbackWithoutHOG(const ImageConstPtr &color,
         oneHypoMsg.score = hyposMDL(i).getScoreMDL();
         oneHypoMsg.speed = hyposMDL(i).getSpeed();
         hyposMDL(i).getDir(dir);
+
+
+        for(int j=0; j < hyposMDL(i).getUbdSeqNr().size(); j++){
+        	oneHypoMsg.index.push_back(hyposMDL(i).getUbdIndex().at(j));
+        	oneHypoMsg.seq.push_back(hyposMDL(i).getUbdSeqNr().at(j));
+        }
+
 
         oneHypoMsg.dir.push_back(dir(0));
         oneHypoMsg.dir.push_back(dir(1));


### PR DESCRIPTION
The changes enable to find out which UBD detections were used for a particular tracker hypothesis by providing sequence numbers of the UBD messages and an index into the arrays within those UBD messages. So using the sequence nr. and the index (provided by the `people_array` message of MDL tracker), one can link back to the data inside the UBD messages.

The most obvious changes are in `MdlPeopleTracker.msg` and a corresponding change is in `Hypo.h`. The important stuff then happens in `Tracker.cpp` within the `extend_trajectories` and `make_new_hypos` methods where the sequence numbers and indices are taken from the detections and pushed into the `Hypo`s. For the rest of the changes is relatively simple to see what they do. Notice little change to `Hypo`'s copy constructor.
@cdondrup 
