### PR TITLE
[bayes_people_tracker] Fixing a bug in calculation of distances and angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ Please see perception_people_launch/README.md for start-up information.
 
 This package contains the people perception pipeline. It is comprised of two detectors:
 * Upper body detector
+* Leg Detector: http://wiki.ros.org/leg_detector
+
+Depricated and moved to attic branch:
 * Ground HOG feature detector
 
 Two trackers:
-* People Tracker
+* Bayesian People Tracker
 * Pedestrian Tracker (currently depricated)
 
-And a lot of utility and helper nodes. 
+And a lot of utility and helper nodes. See https://www.youtube.com/watch?v=zdnvhQU1YNo for a concise explanation. 
 
 Please refere to the READMEs in the specific packages.

--- a/bayes_people_tracker/README.md
+++ b/bayes_people_tracker/README.md
@@ -1,48 +1,58 @@
 ## People Tracker
-This package uses the bayes_tracking library developed by Nicola Bellotto (University of Lincoln): [10.5281/zenodo.10318](http://dx.doi.org/10.5281/zenodo.10318)
+This package uses the bayes_tracking library developed by Nicola Bellotto (University of Lincoln), please cite with: [10.5281/zenodo.15825](https://zenodo.org/record/15825) and [1]
 
 The people_tracker uses a single config file to add an arbitrary amount of detectors. The file `config/detectors.yaml` contains the necessary information for the upper_body_detector and the ROS leg_detector (see `to_pose_array` in detector_msg_to_pose_array/README.md):
 
 ```
 bayes_people_tracker:
+    filter_type: "UKF"                                         # The Kalman filter type: EKF = Extended Kalman Filter, UKF = Uncented Kalman Filter
+    cv_noise_params:                                           # The noise for the constant velocity prediction model
+        x: 1.4
+        y: 1.4
     detectors:                                                 # Add detectors under this namespace
-        upper_body_detector:                                   # Name of detector (used internally to identify them. Has to be unique.
+        upper_body_detector:                                   # Name of detector (used internally to identify them). Has to be unique.
             topic: "/upper_body_detector/bounding_box_centres" # The topic on which the geometry_msgs/PoseArray is published
-            noise_model:
-                velocity:                                      # The std deviation for the constant velocity model
-                    x: 1.4
-                    y: 1.4
-                position:                                      # The std deviation for the cartesian model
-                    x: 1.2
-                    y: 1.2
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
-        leg_detector:                                          # Name of detector (used internally to identify them. Has to be unique.
-            topic: "/to_pose_array/leg_detector" # The topic on which the geometry_msgs/PoseArray is published
-            noise_model:
-                velocity:                                      # The std deviation for the constant velocity model
-                    x: 1.4
-                    y: 1.4
-                position:                                      # The std deviation for the cartesian model
-                    x: 0.2
-                    y: 0.2
-            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN + Joint Probability Data Association
+            cartesian_noise_params:                            # The noise for the cartesian observation model
+                x: 0.5
+                y: 0.5
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN Joint Probability Data Association
+        leg_detector:                                          # Name of detector (used internally to identify them). Has to be unique.
+            topic: "/to_pose_array/leg_detector"               # The topic on which the geometry_msgs/PoseArray is published
+            cartesian_noise_params:                            # The noise for the cartesian observation model
+                x: 0.2
+                y: 0.2
+            matching_algorithm: "NNJPDA"                       # The algorthim to match different detections. NN = Nearest Neighbour, NNJPDA = NN Joint Probability Data Association
 ```
 
 New detectors are added under the parameter namespace `bayes_people_tracker/detectors`. Let's have a look at the upper body detector as an example:
 
+### Tracker Parameters
+
+The tracker offers two configuration parameters:
+* `filter_type`: This specefies which variant of the Kalman filter to use. Currently, it implements an Extended and an Unscented Kalman filter which can be chosen via `EKF` and `UKF`, respectively.
+* `cv_noise_params`: parameter is used for the constant velocity prediction model.
+ * specifies the standard deviation of the x and y velocity.
+
+### Detector Parameters
+
 * For every detector you have to create a new namespace where the name is used as an internal identifier for this detector. Therefore it has to be unique. In this case it is `upper_body_detector`
 * The `topic` parameter specifies the topic under which the detections are published. The type has to be `geometry_msgs/PoseArray`. See `to_pose_array` in detector_msg_to_pose_array/README.md if your detector does not publish a PoseArray.
-* The `noise_model` parameter is used for the Kalman Filter (currently: Extended Kalman Filter).
- * `velocity` specifies the standard deviation in x and y direction of the constant velocity model in meters per second.
- * `position` specifies the standard deviation of x and y in the cartesian model in meters.
-* `matching_algorithm` specifies the algorithm used to match detections from different sensors/detectors. Currently there are three different algorithms which are based on the Mahalanobis distance of the detections (default being NNJPDA if parameter is misspelled):
+* The `cartesian_noise_params` parameter is used for the Cartesian observation model.
+ * specifies the standard deviation of x and y.
+* `matching_algorithm` specifies the algorithm used to match detections from different sensors/detectors. Currently there are two different algorithms which are based on the Mahalanobis distance of the detections (default being NNJPDA if parameter is misspelled):
  * NN: Nearest Neighbour
- * NNJPDA: NN + Joint Probability Data Association
+ * NNJPDA: Nearest Neighbour Joint Probability Data Association
 
 All of these are just normal ROS parameters and can be either specified by the parameter server or using the yaml file in the provided launch file.
 
 ### Message Type:
-The PeopleTracker Message can be found in the `starnds_perception_people` package in the `strands_msgs` repository:
+
+The tracker publishes the following:
+* `pose`: A `geometry_msgs/PoseStamped` for the clostes person.
+* `pose_array`: A `geometry_msgs/PoseArray` for all detections.
+* `people`: A `people_msgs/People` for all detections. Can be used for layerd costmaps.
+* `marker_array`: A `visualization_msgs/MarkerArray` showing little stick figures for every detection. Figures are orient according to the direction of velocity.
+* `positions`: A `bayes_people_tracker/PeopleTracker` message. See below. 
 
 ```
 std_msgs/Header header
@@ -73,3 +83,5 @@ roslaunch bayes_people_tracker people_tracker.launch
 ```
 
 This is the recommended way of launching it since this will also read the config file and set the right parameters for the detectors.
+
+[1] N. Bellotto and H. Hu, “Computationally efficient solutions for tracking people with a mobile robot: an experimental evaluation of bayesian filters,” Autonomous Robots, vol. 28, no. 4, pp. 425–438, 2010.

--- a/bayes_people_tracker/src/people_tracker/people_tracker.cpp
+++ b/bayes_people_tracker/src/people_tracker/people_tracker.cpp
@@ -140,7 +140,7 @@ void PeopleTracker::trackingThread() {
                 } else {
                     poseInRobotCoords = poseInTargetCoords;
                 }
-                std::vector<double> polar = cartesianToPolar(it->second[0].position);
+                std::vector<double> polar = cartesianToPolar(poseInRobotCoords.pose.position);
                 distances.push_back(polar[0]);
                 angles.push_back(polar[1]);
                 angle = polar[0] < min_dist ? polar[1] : angle;
@@ -253,40 +253,22 @@ void PeopleTracker::detectorCallback(const geometry_msgs::PoseArray::ConstPtr &p
         return;
     }
 
-    geometry_msgs::PoseStamped closest_person;
     std::vector<geometry_msgs::Point> ppl;
-    std::vector<int> ids;
-    std::vector<std::string> uuids;
-    std::vector<double> scores;
-    std::vector<double> distances;
-    std::vector<double> angles;
-    double min_dist = 10000.0d;
-    double angle;
     for(int i = 0; i < pta->poses.size(); i++) {
         geometry_msgs::Pose pt = pta->poses[i];
 
             //Create stamped pose for tf
             geometry_msgs::PoseStamped poseInCamCoords;
-//            geometry_msgs::PoseStamped poseInRobotCoords;
             geometry_msgs::PoseStamped poseInTargetCoords;
             poseInCamCoords.header = pta->header;
             poseInCamCoords.pose = pt;
 
             //Transform
             try {
-                // Transform into robot coordinate system /base_link for the caluclation of relative distances and angles
-//                ROS_DEBUG("Transforming received position into %s coordinate system.", BASE_LINK);
-//                listener->waitForTransform(poseInCamCoords.header.frame_id, BASE_LINK, poseInCamCoords.header.stamp, ros::Duration(3.0));
-//                listener->transformPose(BASE_LINK, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInRobotCoords);
-
                 // Transform into given traget frame. Default /map
-//                if(strcmp(target_frame.c_str(), BASE_LINK)) {
-                    ROS_DEBUG("Transforming received position into %s coordinate system.", target_frame.c_str());
-                    listener->waitForTransform(poseInCamCoords.header.frame_id, target_frame, poseInCamCoords.header.stamp, ros::Duration(3.0));
-                    listener->transformPose(target_frame, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInTargetCoords);
-//                } else {
-//                    poseInTargetCoords = poseInRobotCoords;
-//                }
+                ROS_DEBUG("Transforming received position into %s coordinate system.", target_frame.c_str());
+                listener->waitForTransform(poseInCamCoords.header.frame_id, target_frame, poseInCamCoords.header.stamp, ros::Duration(3.0));
+                listener->transformPose(target_frame, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInTargetCoords);
             }
             catch(tf::TransformException ex) {
                 ROS_WARN("Failed transform: %s", ex.what());

--- a/bayes_people_tracker/src/people_tracker/people_tracker.cpp
+++ b/bayes_people_tracker/src/people_tracker/people_tracker.cpp
@@ -120,11 +120,29 @@ void PeopleTracker::trackingThread() {
                 pose.push_back(it->second[0]);
                 vel.push_back(it->second[1]);
                 uuids.push_back(generateUUID(startup_time_str, it->first));
+
+                geometry_msgs::PoseStamped poseInRobotCoords;
+                geometry_msgs::PoseStamped poseInTargetCoords;
+                poseInTargetCoords.header.frame_id = target_frame;
+                poseInTargetCoords.header.stamp.fromSec(time_sec);
+                poseInTargetCoords.pose = it->second[0];
+
+                //Find closest person and get distance and angle
+                if(strcmp(target_frame.c_str(), BASE_LINK) == 0) {
+                    try{
+                        ROS_DEBUG("Transforming received position into %s coordinate system.", BASE_LINK);
+                        listener->waitForTransform(poseInTargetCoords.header.frame_id, BASE_LINK, poseInTargetCoords.header.stamp, ros::Duration(3.0));
+                        listener->transformPose(BASE_LINK, ros::Time(0), poseInTargetCoords, poseInTargetCoords.header.frame_id, poseInRobotCoords);
+                    } catch(tf::TransformException ex) {
+                        ROS_WARN("Failed transform: %s", ex.what());
+                        continue;
+                    }
+                } else {
+                    poseInRobotCoords = poseInTargetCoords;
+                }
                 std::vector<double> polar = cartesianToPolar(it->second[0].position);
                 distances.push_back(polar[0]);
                 angles.push_back(polar[1]);
-
-                //Find closest person and get distance and angle
                 angle = polar[0] < min_dist ? polar[1] : angle;
                 closest_person_point = polar[0] < min_dist ? it->second[0] : closest_person_point;
                 min_dist = polar[0] < min_dist ? polar[0] : min_dist;
@@ -249,7 +267,7 @@ void PeopleTracker::detectorCallback(const geometry_msgs::PoseArray::ConstPtr &p
 
             //Create stamped pose for tf
             geometry_msgs::PoseStamped poseInCamCoords;
-            geometry_msgs::PoseStamped poseInRobotCoords;
+//            geometry_msgs::PoseStamped poseInRobotCoords;
             geometry_msgs::PoseStamped poseInTargetCoords;
             poseInCamCoords.header = pta->header;
             poseInCamCoords.pose = pt;
@@ -257,18 +275,18 @@ void PeopleTracker::detectorCallback(const geometry_msgs::PoseArray::ConstPtr &p
             //Transform
             try {
                 // Transform into robot coordinate system /base_link for the caluclation of relative distances and angles
-                ROS_DEBUG("Transforming received position into %s coordinate system.", BASE_LINK);
-                listener->waitForTransform(poseInCamCoords.header.frame_id, BASE_LINK, poseInCamCoords.header.stamp, ros::Duration(3.0));
-                listener->transformPose(BASE_LINK, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInRobotCoords);
+//                ROS_DEBUG("Transforming received position into %s coordinate system.", BASE_LINK);
+//                listener->waitForTransform(poseInCamCoords.header.frame_id, BASE_LINK, poseInCamCoords.header.stamp, ros::Duration(3.0));
+//                listener->transformPose(BASE_LINK, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInRobotCoords);
 
                 // Transform into given traget frame. Default /map
-                if(strcmp(target_frame.c_str(), BASE_LINK)) {
+//                if(strcmp(target_frame.c_str(), BASE_LINK)) {
                     ROS_DEBUG("Transforming received position into %s coordinate system.", target_frame.c_str());
                     listener->waitForTransform(poseInCamCoords.header.frame_id, target_frame, poseInCamCoords.header.stamp, ros::Duration(3.0));
                     listener->transformPose(target_frame, ros::Time(0), poseInCamCoords, poseInCamCoords.header.frame_id, poseInTargetCoords);
-                } else {
-                    poseInTargetCoords = poseInRobotCoords;
-                }
+//                } else {
+//                    poseInTargetCoords = poseInRobotCoords;
+//                }
             }
             catch(tf::TransformException ex) {
                 ROS_WARN("Failed transform: %s", ex.what());
@@ -276,8 +294,6 @@ void PeopleTracker::detectorCallback(const geometry_msgs::PoseArray::ConstPtr &p
             }
 
             poseInTargetCoords.pose.position.z = 0.0;
-            poseInRobotCoords.pose.position.z = 0.0;
-
             ppl.push_back(poseInTargetCoords.pose.position);
 
     }

--- a/bayes_people_tracker/src/people_tracker/people_tracker.cpp
+++ b/bayes_people_tracker/src/people_tracker/people_tracker.cpp
@@ -128,7 +128,7 @@ void PeopleTracker::trackingThread() {
                 poseInTargetCoords.pose = it->second[0];
 
                 //Find closest person and get distance and angle
-                if(strcmp(target_frame.c_str(), BASE_LINK) == 0) {
+                if(strcmp(target_frame.c_str(), BASE_LINK)) {
                     try{
                         ROS_DEBUG("Transforming received position into %s coordinate system.", BASE_LINK);
                         listener->waitForTransform(poseInTargetCoords.header.frame_id, BASE_LINK, poseInTargetCoords.header.stamp, ros::Duration(3.0));


### PR DESCRIPTION
Due to the transformation to `base_link` being at the wrong position in the code, the distances and angles of the detections to the robot were calculated in the target frame. This is not helpful if run with the default frame of `map`. Using `base_link` transformation at correct location in code now, publishing correct angles and distances. Still need to fix: #149 

Also update some of the readmes.
