### PR TITLE
Adding an emulator for the bayes people tracker

### DIFF
--- a/people_tracker_emulator/CMakeLists.txt
+++ b/people_tracker_emulator/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(people_tracker_emulator)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED)
+
+catkin_python_setup()
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+  CATKIN_DEPENDS bayes_people_tracker geometry_msgs people_msgs rospy std_msgs tf visualization_msgs
+)
+
+#############
+## Install ##
+#############
+
+install(PROGRAMS
+  scripts/posestamped_to_ppl_tracker_msgs.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/people_tracker_emulator/package.xml
+++ b/people_tracker_emulator/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<package>
+  <name>people_tracker_emulator</name>
+  <version>1.1.6</version>
+  <description>The people_tracker_emulator package</description>
+
+  <maintainer email="cdondrup@lincoln.ac.uk">Christian Dondrup</maintainer>
+
+  <license>MIT</license>
+
+  <url type="website">https://github.com/strands-project/strands_perception_people</url>
+
+  <author email="cdondrup@lincoln.ac.uk">Christian Dondrup</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>bayes_people_tracker</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>people_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>visualization_msgs</build_depend>
+
+  <run_depend>bayes_people_tracker</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>people_msgs</run_depend>
+  <run_depend>rospy</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>visualization_msgs</run_depend>
+
+
+  <export/>
+</package>

--- a/people_tracker_emulator/scripts/posestamped_to_ppl_tracker_msgs.py
+++ b/people_tracker_emulator/scripts/posestamped_to_ppl_tracker_msgs.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Jul 28 17:52:31 2015
+
+@author: cdondrup
+"""
+
+import rospy
+from bayes_people_tracker.msg import PeopleTracker
+from geometry_msgs.msg import PoseStamped, PoseArray
+import tf
+from visualization_msgs.msg import MarkerArray
+import people_tracker_emulator.msg_creator as mc
+from people_msgs.msg import People
+
+
+class PeopleTrackerEmulator(object):
+    _uuid = 'fred' # Only one person and no id so we make one up
+    _prev_time = 0.0
+    _prev_pose = None
+
+    def __init__(self, name):
+        rospy.loginfo("Starting %s ..." % name)
+        rospy.Subscriber(rospy.get_param("~pose_in_topic","/human/transformed"), PoseStamped, self.callback)
+        self.pospub = rospy.Publisher(rospy.get_param("~positions","/people_tracker/positions"), PeopleTracker, queue_size=10)
+        self.markpub = rospy.Publisher(rospy.get_param("~marker","/people_tracker/marker_array"), MarkerArray, queue_size=10)
+        self.pplpub = rospy.Publisher(rospy.get_param("~people","/people_tracker/people"), People, queue_size=10)
+        self.posepub = rospy.Publisher(rospy.get_param("~pose","/people_tracker/pose"), PoseStamped, queue_size=10)
+        self.poseapub = rospy.Publisher(rospy.get_param("~pose_array","/people_tracker/pose_array"), PoseArray, queue_size=10)
+        self.tf = tf.TransformListener()
+        self.target_frame = rospy.get_param("~target_frame", "/map")
+        rospy.loginfo("... all done")
+
+    def callback(self, msg):
+        try:
+            t = self.tf.getLatestCommonTime(self.target_frame, msg.header.frame_id)
+            msg.header.stamp = t
+            new_pose = self.tf.transformPose(self.target_frame, msg)
+        except Exception as e:
+            rospy.logwarn(e)
+            return
+
+        self.posepub.publish(new_pose)
+        pa = PoseArray()
+        pa.header = new_pose.header
+        pa.poses.append(new_pose.pose)
+        self.poseapub.publish(pa)
+        p = mc.people_tracker_msg_from_posestamped(self._uuid, new_pose, self.tf)
+        self.pospub.publish(p)
+        marker_array = mc.marker_array_from_people_tracker_msg(p, self.target_frame)
+        self.markpub.publish(marker_array)
+        if self._prev_pose and self._prev_time:
+            dt = msg.header.stamp.to_sec() - self._prev_time
+            ppl = mc.people_msg_from_pose_stamped(self._uuid, new_pose, self._prev_pose, dt)
+            self.pplpub.publish(ppl)
+        self._prev_time = msg.header.stamp.to_sec()
+        self._prev_pose = new_pose
+
+
+if __name__ == "__main__":
+    rospy.init_node("people_tracker_emulator")
+    p = PeopleTrackerEmulator(rospy.get_name())
+    rospy.spin()

--- a/people_tracker_emulator/setup.py
+++ b/people_tracker_emulator/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+# fetch values from package.xml
+setup_args = generate_distutils_setup(
+    packages=['people_tracker_emulator'],
+    package_dir={'': 'src'})
+
+setup(**setup_args)

--- a/people_tracker_emulator/src/people_tracker_emulator/human_marker.py
+++ b/people_tracker_emulator/src/people_tracker_emulator/human_marker.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+
+import rospy
+from geometry_msgs.msg import Vector3, Point, Pose
+from std_msgs.msg import ColorRGBA
+import math
+from tf.transformations import euler_from_quaternion
+from visualization_msgs.msg import Marker
+from copy import deepcopy
+
+
+_marker_seq = 0
+
+def generate_extremity_position(centre, dx, dy, z):
+    angle = euler_from_quaternion(
+        [
+            centre.orientation.x,
+            centre.orientation.y,
+            centre.orientation.z,
+            centre.orientation.w
+        ]
+    )[2] + math.pi/2
+    centre.position.z = z
+    return Pose(position=generate_position(centre.position, angle, dx, dy))
+
+def generate_position(centre, angle, dx, dy):
+  s = math.sin(angle)
+  c = math.cos(angle)
+
+  # rotate point
+  res = Point()
+  res.x = dx * c - dy * s
+  res.y = dx * s + dy * c
+
+  # translate point back:
+  res.x += centre.x
+  res.y += centre.y
+  res.z  = centre.z
+  return res
+
+def createMarker(m_id, m_type, action, pose, scale, color, target_frame):
+    marker = Marker()
+    marker.header.frame_id = target_frame
+    marker.header.stamp = rospy.Time.now()
+    marker.header.seq = _marker_seq
+    global _marker_seq
+    _marker_seq += 1
+    marker.ns = "people_tracker"
+    marker.id = m_id
+    marker.type = m_type
+    marker.action = action
+    marker.pose = pose
+    marker.scale = scale
+    marker.color = color
+    marker.lifetime = rospy.Duration(1)
+    return marker
+
+
+def createHead(m_id, action, pose, target_frame):
+    pose = deepcopy(pose)
+    scale = Vector3()
+    scale.x = 0.3
+    scale.y = 0.3
+    scale.z = 0.3
+    color = ColorRGBA()
+    color.a = 1.0
+    color.r = 233.0/255.0
+    color.g = 150.0/255.0
+    color.b = 122.0/255.0
+    pose.position.z = 1.6
+    return createMarker(m_id, Marker.SPHERE, action, pose, scale, color, target_frame)
+
+
+def createBody(m_id, action, pose, target_frame):
+    pose = deepcopy(pose)
+    scale = Vector3()
+    scale.x = 0.35
+    scale.y = 0.35
+    scale.z = 0.7
+    color = ColorRGBA()
+    color.a = 1.0
+    color.r = 139.0/255.0
+    color.g = 0.0/255.0
+    color.b = 0.0/255.0
+    pose.position.z = 1.1
+    return createMarker(m_id, Marker.CYLINDER, action, pose, scale, color, target_frame)
+
+def createLegs(m_idl, m_idr, action, pose, target_frame):
+    pose = deepcopy(pose)
+    legs = []
+    scale = Vector3()
+    scale.x = 0.15
+    scale.y = 0.2
+    scale.z = 0.8
+    color = ColorRGBA()
+    color.a = 1.0
+    color.r = 0.0/255.0
+    color.g = 0.0/255.0
+    color.b = 139.0/255.0
+    legs.append(
+        createMarker(
+            m_idl,
+            Marker.CYLINDER,
+            action,
+            generate_extremity_position(pose, 0.1, 0.0, 0.4),
+            scale,
+            color,
+            target_frame
+        )
+    )
+    legs.append(
+        createMarker(
+            m_idr,
+            Marker.CYLINDER,
+            action,
+            generate_extremity_position(pose, -0.1, 0.0, 0.4),
+            scale,
+            color,
+            target_frame
+        )
+    )
+    return legs
+
+def createArms(m_idl, m_idr, action, pose, target_frame):
+    pose = deepcopy(pose)
+    arms = []
+    scale = Vector3()
+    scale.x = 0.1
+    scale.y = 0.1
+    scale.z = 0.7
+    color = ColorRGBA()
+    color.a = 1.0
+    color.r = 139.0/255.0
+    color.g = 0.0/255.0
+    color.b = 0.0/255.0
+    arms.append(
+        createMarker(
+            m_idl,
+            Marker.CYLINDER,
+            action,
+            generate_extremity_position(pose, 0.2, 0.0, 1.1),
+            scale,
+            color,
+            target_frame
+        )
+    )
+    arms.append(
+        createMarker(
+            m_idr,
+            Marker.CYLINDER,
+            action,
+            generate_extremity_position(pose, -0.2, 0.0, 1.1),
+            scale,
+            color,
+            target_frame
+        )
+    )
+    return arms;
+
+def createHuman(m_id, pose, target_frame):
+    human = []
+    m_id += 1
+    human.append(createHead(m_id, Marker.ADD, pose, target_frame))
+    m_id += 1
+    human.append(createBody(m_id, Marker.ADD, pose, target_frame))
+    legs = createLegs(m_id+1, m_id+2, Marker.ADD, pose, target_frame)
+    m_id += 3
+    human.extend(legs)
+    arms = createArms(m_id+1, m_id+2, Marker.ADD, pose, target_frame)
+    human.extend(arms)
+    return human

--- a/people_tracker_emulator/src/people_tracker_emulator/msg_creator.py
+++ b/people_tracker_emulator/src/people_tracker_emulator/msg_creator.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+import rospy
+from bayes_people_tracker.msg import PeopleTracker
+from visualization_msgs.msg import MarkerArray
+import math
+import human_marker as hm
+from people_msgs.msg import People, Person
+
+
+def people_tracker_msg_from_posestamped(uuid, pose, tf):
+    try:
+        t = tf.getLatestCommonTime("/base_link", pose.header.frame_id)
+        pose.header.stamp = t
+        base_pose = tf.transformPose("/base_link", pose)
+    except Exception as e:
+        rospy.logwarn(e)
+        return PeopleTracker()
+    p = PeopleTracker()
+    p.uuids.append(uuid)
+    p.poses.append(pose.pose)
+    p.header = pose.header
+    p.distances.append(math.sqrt((base_pose.pose.position.x**2)+(base_pose.pose.position.y**2)))
+    p.angles.append(math.atan2(base_pose.pose.position.y, base_pose.pose.position.x))
+    p.min_distance = p.distances[0]
+    p.min_distance_angle = p.angles[0]
+    return p
+
+def marker_array_from_people_tracker_msg(ppl_tracker_msg, target_frame):
+    marker_array = MarkerArray()
+    for i, pose in enumerate(ppl_tracker_msg.poses):
+        human = hm.createHuman(1, pose, target_frame)
+        marker_array.markers.extend(human)
+    return marker_array
+
+def people_msg_from_pose_stamped(uuid, pose, prev_pose, dt):
+    p = Person()
+    p.name = uuid
+    p.position.x=pose.pose.position.x
+    p.position.y=pose.pose.position.y
+    p.position.z=pose.pose.position.z
+
+    p.velocity.x = (pose.pose.position.x-prev_pose.pose.position.x)/dt
+    p.velocity.y = (pose.pose.position.y-prev_pose.pose.position.y)/dt
+    p.reliability = 1.0
+
+    ppl = People()
+    ppl.header = pose.header
+    ppl.people.append(p)
+    return ppl

--- a/strands_perception_people/package.xml
+++ b/strands_perception_people/package.xml
@@ -8,9 +8,9 @@
 
   <license>MIT</license>
 
-  <url type="website">https://github.com/strands-project/strands_perception_people</url> 
+  <url type="website">https://github.com/strands-project/strands_perception_people</url>
 
-  <author email="cdondrup@lincoln.ac.uk">Christian Dondrup</author> 
+  <author email="cdondrup@lincoln.ac.uk">Christian Dondrup</author>
 
   <buildtool_depend>catkin</buildtool_depend>
   <run_depend>bayes_people_tracker</run_depend>
@@ -25,8 +25,9 @@
   <run_depend>vision_people_logging</run_depend>
   <run_depend>visual_odometry</run_depend>
   <run_depend>human_trajectory</run_depend>
+  <run_depend>people_tracker_emulator</run_depend>
 
   <export>
-    <metapackage/> 
+    <metapackage/>
   </export>
 </package>


### PR DESCRIPTION
This script is meant to be used with the `strands_morse` environment or more specifically the [human pose simulator](https://github.com/strands-project/strands_morse/blob/indigo-devel/scripts/human_pose_simulator.py) which is why the input topic defaults to `/human/transformed`. It also requires a static transform publisher to be running to create a link between the simulator and the robot's tf frame as can be seen in the [uol environment launch file](https://github.com/strands-project/strands_morse/blob/indigo-devel/uol/launch/uol_mht_morse.launch#L7).

Functionality:

Receive a `PoseStamped` and create all the topics that the bayes people tracker would be publishing:
- A `PoseStamped` for the closest person, in this case the only person
- A `PoseArray` for all detected people
- A `MarkerArray` with the visualisation
- A `PeopleTracker` message with uuids and poses
- A `People` message with poses and velocities for social costmaps

This PR only adds code and should therefore not be critical.

I might have been able to reuse the header file from the people_tracker for the visualisation, but I didn't want to do this in C++ ;)
