### PR TITLE
Adding laser filters to launch file

### DIFF
--- a/perception_people_launch/README.md
+++ b/perception_people_launch/README.md
@@ -47,6 +47,7 @@ Parameters:
 * `pd_marker` _default = /people_tracker/marker_array_: A marker arry to visualise found people in rviz
 * `log` _default = false_: Log people and robot locations together with tracking and detection results to message_store database into people_perception collection. Disabled by default because if it is enabled the perception is running continuously.
 * `with_mdl_tracker` _default = false_: Starts the mdl people tracker in addition to the bayes tracker
+* `with_map_filter` _default = true_: Starts the map filter to reduce false positives from the leg detector
 
 
 Running:

--- a/perception_people_launch/launch/people_tracker_robot.launch
+++ b/perception_people_launch/launch/people_tracker_robot.launch
@@ -118,7 +118,7 @@
     <!-- Leg Detector -->
     <group if="$(arg with_map_filter)">
         <node pkg="laser_filters" type="scan_to_scan_filter_chain" respawn="true" name="laser_filter">
-            <rosparam command="load" file="$(find map_laser)/config/filters.yaml" />
+            <rosparam command="load" file="$(find map_laser)/filters.yaml" />
         </node>
         <node pkg="map_laser" type="filter.py" name="map_laser_filter" respawn="true" output="screen"/>
         <node pkg="leg_detector" type="leg_detector" name="leg_detector" args="scan:=/base_scan_filter $(find leg_detector)/config/trained_leg_detector.yaml" respawn="true" output="screen">

--- a/perception_people_launch/launch/people_tracker_robot.launch
+++ b/perception_people_launch/launch/people_tracker_robot.launch
@@ -34,6 +34,7 @@
     <arg name="with_mdl_tracker" default="false"/>
     <arg name="log" default="false" />
     <arg name="manager_topic" default="" />
+    <arg name="with_map_filter" default="true"/>
 
     <arg name="machine" default="localhost" />
     <arg name="user" default="" />
@@ -115,9 +116,20 @@
     </include>
     
     <!-- Leg Detector -->
-    <node pkg="leg_detector" type="leg_detector" name="leg_detector" args="scan:=$(arg scan) $(find leg_detector)/config/trained_leg_detector.yaml" output="screen">
-        <param name="fixed_frame" type="string" value="odom" />
-    </node>
+    <group if="$(arg with_map_filter)">
+        <node pkg="laser_filters" type="scan_to_scan_filter_chain" respawn="true" name="laser_filter">
+            <rosparam command="load" file="$(find map_laser)/config/filters.yaml" />
+        </node>
+        <node pkg="map_laser" type="filter.py" name="map_laser_filter" respawn="true" output="screen"/>
+        <node pkg="leg_detector" type="leg_detector" name="leg_detector" args="scan:=/base_scan_filter $(find leg_detector)/config/trained_leg_detector.yaml" respawn="true" output="screen">
+            <param name="fixed_frame" type="string" value="odom" />
+        </node>
+    </group>
+    <group unless="$(arg with_map_filter)">
+        <node pkg="leg_detector" type="leg_detector" name="leg_detector" args="scan:=$(arg scan) $(find leg_detector)/config/trained_leg_detector.yaml" respawn="true" output="screen">
+            <param name="fixed_frame" type="string" value="odom" />
+        </node>
+    </group>
     
     <!-- Logging -->
     <include file="$(find bayes_people_tracker_logging)/launch/logging.launch">

--- a/perception_people_launch/package.xml
+++ b/perception_people_launch/package.xml
@@ -24,6 +24,8 @@
   <run_depend>leg_detector</run_depend>
   <run_depend>people_msgs</run_depend>
   <run_depend>bayes_people_tracker_logging</run_depend>
+  <run_depend>map_laser</run_depend>
+  <run_depend>laser_filters</run_depend>
   <!--<run_depend>strands_ground_hog</run_depend>-->
 
   <export/>


### PR DESCRIPTION
Closes #171 

This adds the `map_laser` and `laser_filters` package to the run dependencies and launches them when the robot launch file is executed.

The parameter `with_map_filter` is by default `true`. If set to `false` the filter is not run.

Functionality, filter all the laser beams that correspond to obstacles in the static map. Therefore only obstacles that have not been in the environment during the creation of the map will be sent to the leg detector to reduce the number of false positives by tables and other furniture.

Tested on Betty.
