### PR TITLE
New topic names for use with openni2

### DIFF
--- a/ground_plane_estimation/README.md
+++ b/ground_plane_estimation/README.md
@@ -12,7 +12,7 @@ Parameters for estimation:
 * `queue_size` _default = 5_: The synchronisation queue size
 * `config_file` _default = ""_: The global config file. Can be found in ground_plane_estimation/config
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
-* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `depth_image` _default = /depth/image_rect_: `camera_namespace` + `depth_image` = depth image topic
 * `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
 * `ground_plane` _default = /ground_plane_: The estimated ground plane
 

--- a/ground_plane_estimation/launch/ground_plane_estimated.launch
+++ b/ground_plane_estimation/launch/ground_plane_estimated.launch
@@ -5,7 +5,7 @@
 
     <arg name="queue_size" default="5" />
     <arg name="camera_namespace" default="/head_xtion" />
-    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="depth_image" default="/depth/image_rect" />
     <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="ground_plane" default="/ground_plane" />
     <arg name="machine" default="localhost" />

--- a/ground_plane_estimation/src/estimated_gp.cpp
+++ b/ground_plane_estimation/src/estimated_gp.cpp
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("queue_size", queue_size, int(5));
 
     private_node_handle_.param("camera_namespace", cam_ns, string("/head_xtion"));
-    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect_meters"));
+    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect"));
     topic_depth_image = cam_ns + topic_depth_image;
     private_node_handle_.param("camera_info_rgb", topic_camera_info, string("/rgb/camera_info"));
     topic_camera_info = cam_ns + topic_camera_info;

--- a/perception_people_launch/README.md
+++ b/perception_people_launch/README.md
@@ -26,7 +26,7 @@ Parameters:
 * `ptu_state` _default = /ptu/state_: The ptu state topic
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
 * `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
-* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `depth_image` _default = /depth/image_rect_: `camera_namespace` + `depth_image` = depth image topic
 * `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
 * `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
 * `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
@@ -78,7 +78,7 @@ Parameters:
 * `pt_queue_size` _default = 10_: The people tracking sync queue size
 * `camera_namespace` _default = /camera_: The camera namespace.
 * `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
-* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `depth_image` _default = /depth/image_rect_: `camera_namespace` + `depth_image` = depth image topic
 * `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
 * `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
 * `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic

--- a/perception_people_launch/attic/README.md
+++ b/perception_people_launch/attic/README.md
@@ -17,7 +17,7 @@ Parameters:
 * `ptu_state` _default = /ptu/state_: The ptu state topic
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
 * `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
-* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `depth_image` _default = /depth/image_rect_: `camera_namespace` + `depth_image` = depth image topic
 * `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
 * `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
 * `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
@@ -55,7 +55,7 @@ Parameters:
 * `pt_queue_size` _default = 10_: The people tracking sync queue size
 * `camera_namespace` _default = /camera_: The camera namespace.
 * `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
-* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `depth_image` _default = /depth/image_rect_: `camera_namespace` + `depth_image` = depth image topic
 * `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
 * `camera_info_rgb` _default = /rgb/camera_info_: `camera_namespace` + `camera_info_rgb` = rgb camera info topic
 * `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic

--- a/perception_people_launch/attic/people_tracker_robot_with_HOG.launch
+++ b/perception_people_launch/attic/people_tracker_robot_with_HOG.launch
@@ -9,7 +9,7 @@
     <arg name="ptu_state" default="/ptu/state" />
     <arg name="camera_namespace" default="/head_xtion" />
     <arg name="rgb_image" default="/rgb/image_rect_color" />
-    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="depth_image" default="/depth/image_rect" />
     <arg name="mono_image" default="/rgb/image_mono" />
     <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="camera_info_depth" default="/depth/camera_info" />

--- a/perception_people_launch/attic/people_tracker_standalone_with_HOG.launch
+++ b/perception_people_launch/attic/people_tracker_standalone_with_HOG.launch
@@ -8,7 +8,7 @@
     <arg name="pt_queue_size" default="10" />
     <arg name="camera_namespace" default="/camera" />
     <arg name="rgb_image" default="/rgb/image_rect_color" />
-    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="depth_image" default="/depth/image_rect" />
     <arg name="mono_image" default="/rgb/image_mono" />
     <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="camera_info_depth" default="/depth/camera_info" />

--- a/perception_people_launch/launch/people_tracker_robot.launch
+++ b/perception_people_launch/launch/people_tracker_robot.launch
@@ -8,7 +8,7 @@
     <arg name="ptu_state" default="/ptu/state" />
     <arg name="camera_namespace" default="/head_xtion" />
     <arg name="rgb_image" default="/rgb/image_rect_color" />
-    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="depth_image" default="/depth/image_rect" />
     <arg name="mono_image" default="/rgb/image_mono" />
     <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="camera_info_depth" default="/depth/camera_info" />

--- a/perception_people_launch/launch/people_tracker_standalone.launch
+++ b/perception_people_launch/launch/people_tracker_standalone.launch
@@ -7,7 +7,7 @@
     <arg name="pt_queue_size" default="10" />
     <arg name="camera_namespace" default="/camera" />
     <arg name="rgb_image" default="/rgb/image_rect_color" />
-    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="depth_image" default="/depth/image_rect" />
     <arg name="mono_image" default="/rgb/image_mono" />
     <arg name="camera_info_rgb" default="/rgb/camera_info" />
     <arg name="camera_info_depth" default="/depth/camera_info" />

--- a/upper_body_detector/README.md
+++ b/upper_body_detector/README.md
@@ -12,7 +12,7 @@ Parameters:
 * `config_file` _default = ""_: The global config file. Can be found in strands_upper_bodydetector/config
 * `template_file` _default = ""_: The template file. Can be found in config.
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
-* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `depth_image` _default = /depth/image_rect_: `camera_namespace` + `depth_image` = depth image topic
 * `rgb_image` _default = /rgb/image_rect_color_: `camera_namespace` + `rgb_image` = rgb image topic
 * `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `ground_plane` _default = /ground_plane_: The estimated/fixed ground plane

--- a/upper_body_detector/launch/upper_body_detector.launch
+++ b/upper_body_detector/launch/upper_body_detector.launch
@@ -7,7 +7,7 @@
     
     <arg name="queue_size" default="5" />
     <arg name="camera_namespace" default="/head_xtion" />
-    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="depth_image" default="/depth/image_rect" />
     <arg name="rgb_image" default="/rgb/image_rect_color" />
     <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="upper_body_detections" default="/upper_body_detector/detections" />

--- a/upper_body_detector/src/main.cpp
+++ b/upper_body_detector/src/main.cpp
@@ -363,7 +363,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("camera_info_depth", topic_camera_info, string("/depth/camera_info"));
     topic_camera_info = cam_ns + topic_camera_info;
     string topic_depth_image;
-    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect_meters"));
+    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect"));
     topic_depth_image = cam_ns + topic_depth_image;
 
     // Printing queue size

--- a/upper_body_detector/src/main.cpp
+++ b/upper_body_detector/src/main.cpp
@@ -264,7 +264,7 @@ void callback(const ImageConstPtr &depth, const ImageConstPtr &color,const Groun
         // Make a copy here so that in case `render_bbox_2D` corrupts memory,
         // we don't corrupt the original buffer in the ROS message and may get better stacktraces.
         QImage image_rgb = QImage(&color->data[0], color->width, color->height, color->step, QImage::Format_RGB888).copy();
-        render_bbox_2D(detection_msg, image_rgb, 0, 0, 255, 2);
+        render_bbox_2D(detection_msg, image_rgb, 255, 0, 0, 2);
         const uchar *bits = image_rgb.constBits();
 
         sensor_msgs::Image sensor_image;

--- a/vision_people_logging/scripts/save_ubd.py
+++ b/vision_people_logging/scripts/save_ubd.py
@@ -29,7 +29,7 @@ class SaveLocations():
             message_filters.Subscriber(rospy.get_param("~ubd", "/upper_body_detector/detections"), UpperBodyDetector),
             message_filters.Subscriber(rospy.get_param("~ubd_cent", "/upper_body_detector/bounding_box_centres"), geometry_msgs.msg.PoseArray),
             message_filters.Subscriber(rospy.get_param("~ubd_rgb", "/head_xtion/rgb/image_rect_color"), sensor_msgs.msg.Image),
-            message_filters.Subscriber(rospy.get_param("~ubd_d", "/head_xtion/depth/image_rect_meters"), sensor_msgs.msg.Image),
+            message_filters.Subscriber(rospy.get_param("~ubd_d", "/head_xtion/depth/image_rect"), sensor_msgs.msg.Image),
         ]
 
         # Potentially also make use of the manager to tell us whether

--- a/visual_odometry/README.md
+++ b/visual_odometry/README.md
@@ -5,7 +5,7 @@ This package calculates the visual odometry using depth and mono images.
 Parameters:
 * `queue_size` _default = 20_: The synchronisation queue size
 * `camera_namespace` _default = /head_xtion_: The camera namespace.
-* `depth_image` _default = /depth/image_rect_meters_: `camera_namespace` + `depth_image` = depth image topic
+* `depth_image` _default = /depth/image_rect_: `camera_namespace` + `depth_image` = depth image topic
 * `mono_image` _default = /rgb/image_mono_: `camera_namespace` + `mono_image` = mono image topic
 * `camera_info_depth` _default = /depth/camera_info_: `camera_namespace` + `camera_info_depth` = depth camera info topic
 * `motion_parameters` _default = /visual_odometry/motion_matrix_: The visual odometry

--- a/visual_odometry/launch/visual_odometry.launch
+++ b/visual_odometry/launch/visual_odometry.launch
@@ -1,7 +1,7 @@
 <launch>
     <arg name="queue_size" default="5" />
     <arg name="camera_namespace" default="/head_xtion" />
-    <arg name="depth_image" default="/depth/image_rect_meters" />
+    <arg name="depth_image" default="/depth/image_rect" />
     <arg name="mono_image" default="/rgb/image_mono" />
     <arg name="camera_info_depth" default="/depth/camera_info" />
     <arg name="motion_parameters" default="/visual_odometry/motion_matrix" />

--- a/visual_odometry/src/main.cpp
+++ b/visual_odometry/src/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char **argv)
     private_node_handle_.param("camera_info_depth", topic_camera_info, string("/depth/camera_info"));
     topic_camera_info = cam_ns + topic_camera_info;
     string topic_depth_image;
-    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect_meters"));
+    private_node_handle_.param("depth_image", topic_depth_image, string("/depth/image_rect"));
     topic_depth_image = cam_ns + topic_depth_image;
 
     ROS_DEBUG("visual_odometry: Queue size for synchronisation is set to: %i", queue_size);


### PR DESCRIPTION
This changes the default topic name for the depth image to `/<camera>/depth/image_rect` to make it work with openni2.

Also changes the bbox colour of the ubd back to red since the colour image is now rgb instead of bgr.

Needs https://github.com/strands-project/strands_systems/pull/114 merged.

Tested on Linda.
