### PR TITLE
Adding service to create new uuid in emulator

### DIFF
--- a/people_tracker_emulator/scripts/posestamped_to_ppl_tracker_msgs.py
+++ b/people_tracker_emulator/scripts/posestamped_to_ppl_tracker_msgs.py
@@ -13,6 +13,8 @@ import tf
 from visualization_msgs.msg import MarkerArray
 import people_tracker_emulator.msg_creator as mc
 from people_msgs.msg import People
+from std_srvs.srv import Empty, EmptyResponse
+import uuid
 
 
 class PeopleTrackerEmulator(object):
@@ -28,9 +30,14 @@ class PeopleTrackerEmulator(object):
         self.pplpub = rospy.Publisher(rospy.get_param("~people","/people_tracker/people"), People, queue_size=10)
         self.posepub = rospy.Publisher(rospy.get_param("~pose","/people_tracker/pose"), PoseStamped, queue_size=10)
         self.poseapub = rospy.Publisher(rospy.get_param("~pose_array","/people_tracker/pose_array"), PoseArray, queue_size=10)
+        rospy.Service("~new_id", Empty, self.srv_cb)
         self.tf = tf.TransformListener()
         self.target_frame = rospy.get_param("~target_frame", "/map")
         rospy.loginfo("... all done")
+
+    def srv_cb(self, req):
+        self._uuid = uuid.uuid1().hex
+        return EmptyResponse()
 
     def callback(self, msg):
         try:


### PR DESCRIPTION
As easy as the title suggests: call service, human will get new id.

To simulate that a new human is detected, e.g. after the human has been teleported somewhere, you can can call the service `~new_id` to assign it a new uuid which should result in every listening component treating the human in simulation as a new track and therefore different person.

Tested in simulation obviously ;)
