### PR TITLE
Adding people_tracker_filter to run dependencies of meta and launch package

### DIFF
--- a/perception_people_launch/package.xml
+++ b/perception_people_launch/package.xml
@@ -26,6 +26,7 @@
   <run_depend>bayes_people_tracker_logging</run_depend>
   <run_depend>map_laser</run_depend>
   <run_depend>laser_filters</run_depend>
+  <run_depend>people_tracker_filter</run_depend>
   <!--<run_depend>strands_ground_hog</run_depend>-->
 
   <export/>

--- a/strands_perception_people/package.xml
+++ b/strands_perception_people/package.xml
@@ -26,6 +26,7 @@
   <run_depend>visual_odometry</run_depend>
   <run_depend>human_trajectory</run_depend>
   <run_depend>people_tracker_emulator</run_depend>
+  <run_depend>people_tracker_filter</run_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
Currently, the overall launch file will break because the `people_tracker_filter` is not installed by default.

Once Jenkins approves, I'll merge and re-release.
