### PR TITLE
Fix for visual odometry motion matrix+MDL Tracker

### DIFF
--- a/odometry_to_motion_matrix/CMakeLists.txt
+++ b/odometry_to_motion_matrix/CMakeLists.txt
@@ -46,6 +46,13 @@ target_link_libraries(odom2visual
   ${catkin_LIBRARIES}
 )
 
+add_executable(tf2visual src/odom2visual/tf2visual.cpp)
+add_dependencies(tf2visual ${catkin_EXPORTED_TARGETS})
+target_link_libraries(tf2visual
+  ${catkin_LIBRARIES}
+)
+
+
 #############
 ## Install ##
 #############

--- a/odometry_to_motion_matrix/launch/tf2visual.launch
+++ b/odometry_to_motion_matrix/launch/tf2visual.launch
@@ -1,0 +1,13 @@
+<launch>
+    <arg name="camera_namespace" default="/head_xtion" />
+    <arg name="motion_parameters" default="/visual_odometry/motion_matrix" />
+    <arg name="machine" default="localhost" />
+    <arg name="user" default="" />
+
+    <machine name="$(arg machine)" address="$(arg machine)" env-loader="$(optenv ROS_ENV_LOADER )" user="$(arg user)" default="true"/>
+
+    <node pkg="odometry_to_motion_matrix" type="tf2visual" name="tf2visual" output="screen">
+        <param name="motion_parameters" value="$(arg motion_parameters)" type="string"/>
+        <param name="sensor_frame_id" value="$(arg camera_namespace)_rgb_optical_frame"/>
+    </node>
+</launch> 

--- a/odometry_to_motion_matrix/src/odom2visual/tf2visual.cpp
+++ b/odometry_to_motion_matrix/src/odom2visual/tf2visual.cpp
@@ -1,0 +1,91 @@
+// ROS includes.
+#include <ros/ros.h>
+#include <ros/time.h>
+#include <tf/transform_listener.h>
+#include <tf/transform_datatypes.h>
+#include <tf_conversions/tf_eigen.h>
+#include <eigen_conversions/eigen_msg.h>
+
+#include <Eigen/Geometry>
+
+
+#include "visual_odometry/VisualOdometry.h"
+
+ros::Publisher pub_message;
+
+
+int main(int argc, char **argv)
+{
+    // Set up ROS.
+    ros::init(argc, argv, "tf2visual");
+    ros::NodeHandle n;
+
+    std::string pub_topic;
+    std::string sensor_frame_id;
+
+
+    // Initialize node parameters from launch file or command line.
+    // Use a private node handle so that multiple instances of the node can be run simultaneously
+    // while using different parameters.
+    ros::NodeHandle private_node_handle_("~");
+
+    private_node_handle_.param("motion_parameters", pub_topic, std::string("/visual_odometry/motion_matrix"));
+    private_node_handle_.param("sensor_frame_id", sensor_frame_id, std::string("head_xtion_rgb_optical_frame"));
+    pub_message = n.advertise<visual_odometry::VisualOdometry>(pub_topic.c_str(), 3);
+
+    tf::TransformListener listener;
+
+    ros::Rate updateRate(30.0);
+    while(ros::ok()) {
+        ros::spinOnce();
+        updateRate.sleep();
+
+        tf::StampedTransform transform;
+        try{
+          listener.lookupTransform(sensor_frame_id, "odom", ros::Time(0), transform);
+        }
+        catch (tf::TransformException &ex) {
+          ROS_WARN_THROTTLE(10.0, "Failed to lookup transform in tf2visual: %s",ex.what());
+        }
+
+        Eigen::Affine3d finalTransform;
+        tf::transformTFToEigen(transform, finalTransform);
+
+        Eigen::Matrix4d ros2tracker_R;
+        ros2tracker_R << 0,-1,0,0, 0,0,-1,0, 1,0,0,0, 0,0,0,1;
+
+        Eigen::Matrix4d finalMatrix = finalTransform.matrix().inverse();
+
+        Eigen::Matrix4d rotatedFinalMatrix = (ros2tracker_R*finalMatrix);
+
+        // and mirror at x-z-plane (turns a +0 in a -0 in t and does sth. to R, but still...)
+        /*Eigen::Affine3d mirrorTransform;
+        mirrorTransform.setIdentity();
+        Eigen::Matrix3d A_rh = mirrorTransform.linear();
+        Eigen::Vector3d b_rh = mirrorTransform.translation();
+
+        Eigen::Matrix3d S_y; S_y << 1, 0, 0,   0, -1, 0,  0, 0, 1;
+
+        Eigen::Matrix3d A_lh = S_y * A_rh * S_y;
+        Eigen::Vector3d b_lh = S_y * b_rh;
+
+        Eigen::Affine3d finalMirrorTransform;
+        finalMirrorTransform.linear() = A_lh;
+        finalMirrorTransform.translation() = b_lh;*/
+
+        //Eigen::Matrix4d reallyFinalMatrix = (finalMirrorTransform*rotatedFinalMatrix).matrix().transpose();
+        Eigen::Matrix4d reallyFinalMatrix = rotatedFinalMatrix.transpose();
+
+        visual_odometry::VisualOdometry fovis_info_msg;
+        fovis_info_msg.header.frame_id = sensor_frame_id;
+        fovis_info_msg.header.stamp = transform.stamp_;
+        fovis_info_msg.motion_estimate_valid = true;
+        fovis_info_msg.transformation_matrix.resize(4*4);
+        for(int i = 0; i < 4*4; i++)
+            fovis_info_msg.transformation_matrix[i] = reallyFinalMatrix.data()[i];
+         pub_message.publish(fovis_info_msg);
+    }
+
+
+    return 0;
+}

--- a/perception_people_launch/launch/people_tracker_robot.launch
+++ b/perception_people_launch/launch/people_tracker_robot.launch
@@ -78,10 +78,10 @@
 
     <group if="$(arg with_mdl_tracker)">
         <!-- Odometry -->
-        <include file="$(find odometry_to_motion_matrix)/launch/odom2visual.launch">
+        <include file="$(find odometry_to_motion_matrix)/launch/tf2visual.launch">
             <arg name="machine" value="$(arg machine)"/>
             <arg name="user" value="$(arg user)"/>
-            <arg name="odom" value="$(arg odom)"/>
+            <arg name="camera_namespace" value="$(arg camera_namespace)"/>
             <arg name="motion_parameters" value="$(arg visual_odometry)"/>
         </include>
 


### PR DESCRIPTION
The odometry motion matrix is now calculated based on the tf-tree and transformed in the frame used by the MDL-tracker.
This fixes the MDL-tracker, which can then be run by adding "with_mdl_tracker:=true" when launching people_tracker_robot.launch, just like before.