### PR TITLE
Adds 2d tracked persons message

### DIFF
--- a/mdl_people_tracker/CMakeLists.txt
+++ b/mdl_people_tracker/CMakeLists.txt
@@ -36,6 +36,8 @@ add_message_files(
   FILES
   MdlPeopleTracker.msg
   MdlPeopleTrackerArray.msg
+  TrackedPerson2d.msg
+  TrackedPersons2d.msg
 )
 
 generate_messages(

--- a/mdl_people_tracker/include/AncillaryMethods.h
+++ b/mdl_people_tracker/include/AncillaryMethods.h
@@ -95,6 +95,7 @@ public:
 
 
     static Vector<double> fromWorldToCamera(Vector<double>& posInWorld, Camera& cam);
+    static Vector<double> fromCameraToWorld(Vector<double>& posInCamera, Camera& cam);
 
     ///////////////// Segmentation part /////////////////////////////////////////
     static Matrix<double> conv1D(Matrix<double> &im, Vector<double> &kernel, bool dirFlag);

--- a/mdl_people_tracker/msg/TrackedPerson2d.msg
+++ b/mdl_people_tracker/msg/TrackedPerson2d.msg
@@ -1,0 +1,10 @@
+# Message defining a 2d image bbox of a tracked person
+#
+
+uint64      track_id        # unique identifier of the target, consistent over time
+float32     person_height   # 3d height of person in m
+int32       x               # top left corner x of 2d image bbox
+int32       y               # top left corner y of 2d image bbox
+uint32      w               # width of 2d image bbox
+uint32      h               # height of 2d image bbox
+float32     depth           # distance from the camera in m

--- a/mdl_people_tracker/msg/TrackedPersons2d.msg
+++ b/mdl_people_tracker/msg/TrackedPersons2d.msg
@@ -1,0 +1,5 @@
+# Message with all 2d bbox in image of currently tracked persons 
+#
+
+Header                header      # Header containing timestamp etc. of this message
+TrackedPerson2d[]     boxes       # All persons that are currently being tracked (2d image bbox)

--- a/mdl_people_tracker/src/AncillaryMethods.cpp
+++ b/mdl_people_tracker/src/AncillaryMethods.cpp
@@ -938,3 +938,31 @@ Vector<double> AncillaryMethods::fromWorldToCamera(Vector<double>& posInWorld, C
     Vector<double> posInCam = RT*(posInWorld-t);
     return posInCam;
 }
+
+Vector<double> AncillaryMethods::fromCameraToWorld(Vector<double>& posInCamera, Camera& cam)
+{
+    Matrix<double> rotMat = cam.get_R();
+
+    Vector<double> posCam = cam.get_t();
+
+    Matrix<double> trMat(4,4,0.0);
+    trMat(3,3) = 1;
+    trMat(0,0) = rotMat(0,0);
+    trMat(0,1) = rotMat(0,1);
+    trMat(0,2) = rotMat(0,2);
+    trMat(1,0) = rotMat(1,0);
+    trMat(1,1) = rotMat(1,1);
+    trMat(1,2) = rotMat(1,2);
+    trMat(2,0) = rotMat(2,0);
+    trMat(2,1) = rotMat(2,1);
+    trMat(2,2) = rotMat(2,2);
+
+    posCam *= Globals::WORLD_SCALE;
+
+    trMat(3,0) = posCam(0);
+    trMat(3,1) = posCam(1);
+    trMat(3,2) = posCam(2);
+
+    Vector<double> posInWorld = trMat*posInCamera;
+    return posInWorld;
+}


### PR DESCRIPTION
Adds a new message "TrackedPersons2d", giving the 2d image box position, ID, depth and 3d height of tracked persons. It is published by the MDL tracker, which can then be used as input for further analysis components (e.g. skeleton estimation or head-pose analysis). It is published by default in /mdl_people_tracker/tracked_persons_2d.